### PR TITLE
Reformat Mutant Copy Number column

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -116,7 +116,7 @@ export default class PatientViewMutationTable extends MutationTable<IPatientView
             name: "Mutant Copies",
              tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
             render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap, this.getSamples()),
-            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValue(d, this.props.sampleIdToClinicalDataMap, this.getSamples())        
+            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, this.getSamples())        
         };
 
         // customization for allele count columns

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -442,8 +442,8 @@ export default class MutationTable<P extends IMutationTableProps> extends React.
             name: "Mutant Copies",
             tooltip: (<span>FACETS Best Guess for Mutant Copies / Total Copies</span>),
             render:(d:Mutation[])=>MutantCopiesColumnFormatter.renderFunction(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]),
-            download:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValue(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]),
-            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValue(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId])
+            download:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId]),
+            sortBy:(d:Mutation[])=>MutantCopiesColumnFormatter.getDisplayValueAsString(d, this.props.sampleIdToClinicalDataMap, [d[0].sampleId])
         };
 
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT] = {

--- a/src/shared/components/mutationTable/column/MutantCopiesColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutantCopiesColumnFormatter.tsx
@@ -22,25 +22,25 @@ export default class MutantCopiesColumnFormatter
      * @param data  column formatter data
      * @returns {string}    mutation assessor text value
      */
-    public static getDisplayValue(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):string
+    public static getDisplayValue(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):{[key: string]: string}
     {
-        let values = [];
         const sampleToValue:{[key: string]: string} = {};
         for (const mutation of data) {
-            sampleToValue[mutation.sampleId] = MutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies([mutation], sampleIdToClinicalDataMap);
+            const value:string = MutantCopiesColumnFormatter.getMutantCopiesOverTotalCopies(mutation, sampleIdToClinicalDataMap);
+            if (value.toString().length > 0) {
+                sampleToValue[mutation.sampleId] = value;
+            }
         }
-        const samplesWithValue = sampleIds.filter(sampleId =>
-                sampleToValue[sampleId] && sampleToValue[sampleId].toString().length > 0);
-        if (!samplesWithValue) {
-            return "";
-        } else if (samplesWithValue.length === 1) {
-             return sampleToValue[samplesWithValue[0]];
-        } else {
-            let toReturn:string[] = samplesWithValue.map((sampleId:string) => {
-                return sampleToValue[sampleId];
-            });
-            return toReturn.join("; ");
-        }
+        return sampleToValue;
+    }
+
+    public static getDisplayValueAsString(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[]):string {
+        const displayValuesBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
+        const sampleIdsWithValues = sampleIds.filter(sampleId => displayValuesBySample[sampleId]);
+        const displayValuesAsString = sampleIdsWithValues.map((sampleId:string) => {
+            return displayValuesBySample[sampleId];
+        })
+        return displayValuesAsString.join("; ");
     }
 
     public static invalidTotalCopyNumber(value:number):boolean
@@ -51,22 +51,20 @@ export default class MutantCopiesColumnFormatter
         return false;
     }
 
-    public static getVariantAlleleFraction(data:Mutation[]):number
+    public static getVariantAlleleFraction(mutation:Mutation):number
     {
         let variantAlleleFraction = 0;
-        if (data.length > 0) {
-            const refreads:number = data[0].tumorRefCount;
-            const altreads:number = data[0].tumorAltCount;
-            variantAlleleFraction = altreads/(refreads + altreads);
+        if (mutation.tumorRefCount !== null && mutation.tumorAltCount !== null) {
+            variantAlleleFraction = mutation.tumorAltCount/(mutation.tumorRefCount + mutation.tumorAltCount);
         }
         return variantAlleleFraction;
     }
 
-    public static getMutantCopies(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):number
+    public static getMutantCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):number
     {
-        const sampleId:string = data[0].sampleId;
-        const variantAlleleFraction:number = MutantCopiesColumnFormatter.getVariantAlleleFraction(data);
-        const totalCopyNumber = data[0].totalCopyNumber;
+        const sampleId:string = mutation.sampleId;
+        const variantAlleleFraction:number = MutantCopiesColumnFormatter.getVariantAlleleFraction(mutation);
+        const totalCopyNumber = mutation.totalCopyNumber;
         let purity = null;
         if (sampleIdToClinicalDataMap) {
             const purityData = sampleIdToClinicalDataMap[sampleId].filter((cd: ClinicalData) => cd.clinicalAttributeId === "FACETS_PURITY");
@@ -81,11 +79,11 @@ export default class MutantCopiesColumnFormatter
         return mutantCopies;
     }
  
-    public static getMutantCopiesOverTotalCopies(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string
+    public static getMutantCopiesOverTotalCopies(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string
     {
         let textValue:string = "";
-        const totalCopyNumber:number = data[0].totalCopyNumber;
-        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(data, sampleIdToClinicalDataMap)
+        const totalCopyNumber:number = mutation.totalCopyNumber;
+        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap)
         if (mutantCopies === -1 || MutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
             textValue = "";
         } else {
@@ -93,12 +91,31 @@ export default class MutantCopiesColumnFormatter
         }
         return textValue;
     }
-        
-    public static getMutantCopiesToolTip(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string
+
+    /**
+     * Returns map of sample id to tooltip text value.
+     * @param data 
+     * @param sampleIdToClinicalDataMap 
+     * @param sampleIdsWithValues 
+     */
+    public static getMutantCopiesToolTip(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIdsWithValues:string[]):{[key: string]: string}
     {
+        const sampleToToolTip:{[key: string]: string} = {};
+        for (const mutation of data) {
+            sampleToToolTip[mutation.sampleId] = MutantCopiesColumnFormatter.constructToolTipString(mutation, sampleIdToClinicalDataMap);
+        }
+        return sampleToToolTip;
+    }
+    
+    /**
+     * Constructs tooltip string value.
+     * @param mutation 
+     * @param sampleIdToClinicalDataMap 
+     */
+    public static constructToolTipString(mutation:Mutation, sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined):string {
         let textValue:string = "";
-        const totalCopyNumber:number = data[0].totalCopyNumber;
-        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(data, sampleIdToClinicalDataMap);
+        const totalCopyNumber:number = mutation.totalCopyNumber;
+        const mutantCopies:number = MutantCopiesColumnFormatter.getMutantCopies(mutation, sampleIdToClinicalDataMap);
         if (mutantCopies === -1 || MutantCopiesColumnFormatter.invalidTotalCopyNumber(totalCopyNumber)) {
             textValue = "Missing data values, mutant copies can not be computed";
         } else {
@@ -106,21 +123,31 @@ export default class MutantCopiesColumnFormatter
         }
         return textValue;
     }
-    
+
     public static renderFunction(data:Mutation[], sampleIdToClinicalDataMap:{[sampleId:string]:ClinicalData[]}|undefined, sampleIds:string[])
     {
-        // use text for all purposes (display, sort, filter)
-        const text:string = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
-        // use actual value for tooltip
-        const toolTip:string = MutantCopiesColumnFormatter.getMutantCopiesToolTip(data, sampleIdToClinicalDataMap);
-        let content = <span>{text}</span>;
-        const arrowContent = <div className="rc-tooltip-arrow-inner"/>;
-        content = (
-            <DefaultTooltip overlay={<span>{toolTip}</span>} placement="left" arrowContent={arrowContent}>
-                {content}
-            </DefaultTooltip>
-        );
-        return content;
+        // get display text values map (sampleid -> value), list of sample ids with values in 'displayValuesBySample', and calculate tooltip by sample
+        const displayValuesBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getDisplayValue(data, sampleIdToClinicalDataMap, sampleIds);
+        const sampleIdsWithValues = sampleIds.filter(sampleId => displayValuesBySample[sampleId]);
+        const toolTipBySample:{[key: string]: string} = MutantCopiesColumnFormatter.getMutantCopiesToolTip(data, sampleIdToClinicalDataMap, sampleIdsWithValues);
+        
+        if (!sampleIdsWithValues) {
+            return (<span></span>);
+        } else {
+            let content = sampleIdsWithValues.map((sampleId:string) => {
+                let textValue = displayValuesBySample[sampleId];
+                // if current item is not last samle in list then append '; ' to end of text value
+                if (sampleIdsWithValues.indexOf(sampleId) !== (sampleIdsWithValues.length - 1)) {
+                    textValue = textValue + "; ";
+                }
+                return <li><DefaultTooltip overlay={<span>{toolTipBySample[sampleId]}</span>} placement='left' arrowContent={<div className="rc-tooltip-arrow-inner"/>}><span>{textValue}</span></DefaultTooltip></li>
+            })
+            return (
+             <span style={{display:'inline-block', minWidth:100}}>
+                 <ul style={{marginBottom:0}} className="list-inline list-unstyled">{ content }</ul>
+             </span> 
+            );
+       }
+
     }
 }
-


### PR DESCRIPTION
Tooltip is assigned to each text value in mutant copies column, even ';'-delim values separately.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>
