### PR TITLE
Rename MutationTable ASCN property checker function

### DIFF
--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -314,7 +314,7 @@ export default class PatientViewMutationTable extends MutationTable<
         };
 
         this._columns[MutationTableColumnType.CLONAL].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.CCF_M_COPIES_STRING
             );
         };
@@ -322,7 +322,7 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.ASCN_METHOD
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.ASCN_METHOD_STRING
             );
         };
@@ -330,7 +330,7 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.CANCER_CELL_FRACTION
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.CCF_M_COPIES_STRING
             );
         };
@@ -338,7 +338,7 @@ export default class PatientViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.MUTANT_COPIES
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.MUTANT_COPIES_STRING
             );
         };

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -140,7 +140,7 @@ export default class ResultsViewMutationTable extends MutationTable<
         };
 
         this._columns[MutationTableColumnType.CLONAL].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.CCF_M_COPIES_STRING
             );
         };
@@ -148,7 +148,7 @@ export default class ResultsViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.ASCN_METHOD
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.ASCN_METHOD_STRING
             );
         };
@@ -156,7 +156,7 @@ export default class ResultsViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.CANCER_CELL_FRACTION
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.CCF_M_COPIES_STRING
             );
         };
@@ -164,7 +164,7 @@ export default class ResultsViewMutationTable extends MutationTable<
         this._columns[
             MutationTableColumnType.MUTANT_COPIES
         ].shouldExclude = () => {
-            return !this.hasRequiredASCNProperty(
+            return !this.anyMutationHasASCNProperty(
                 ASCNAttributes.MUTANT_COPIES_STRING
             );
         };

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -77,6 +77,7 @@ import { getDefaultASCNMethodColumnDefinition } from 'shared/components/mutation
 import { getDefaultCancerCellFractionColumnDefinition } from 'shared/components/mutationTable/column/cancerCellFraction/CancerCellFractionColumnFormatter';
 import { getDefaultClonalColumnDefinition } from 'shared/components/mutationTable/column/clonal/ClonalColumnFormatter';
 import { getDefaultMutantCopiesColumnDefinition } from 'shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter';
+import { hasASCNProperty } from 'shared/lib/MutationUtils';
 
 export interface IMutationTableProps {
     studyIdToStudy?: { [studyId: string]: CancerStudy };
@@ -1140,19 +1141,14 @@ export default class MutationTable<
      * @param property the field name to search for
      * @returns true if any available mutation is annotated with the passed property name
      */
-    protected hasRequiredASCNProperty(property: string): boolean {
+    protected anyMutationHasASCNProperty(property: string): boolean {
         let data = this.getMutations();
         if (data) {
             return data.some((row: Mutation[]) => {
                 /* if at least one row ... */
                 return row.some((m: Mutation) => {
                     /* contains at least one mutation record ... */
-                    return (
-                        /*  with ASCN annotations which have a value for key [property] */
-                        m.alleleSpecificCopyNumber !== undefined &&
-                        (m.alleleSpecificCopyNumber as any)[property] !==
-                            undefined
-                    );
+                    return hasASCNProperty(m, property);
                 });
             });
         }


### PR DESCRIPTION
- Renamed function in MutationTable from "hasRequiredASCNProperty" to "anyMutationHasASCNProperty"
- Now imports "hasASCNProperty" from MutationUtils and is called by "anyMutationHasASCNProperty".

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
