### PR TITLE
add/use additional string constants for api calls

### DIFF
--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
@@ -9,6 +9,7 @@ import ASCNCopyNumberElement from 'shared/components/mutationTable/column/ascnCo
 import { ASCNCopyNumberValue } from 'shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement';
 import { ASCN_BLACK } from 'shared/lib/Colors';
 import { getASCNCopyNumberColor } from 'shared/lib/ASCNUtils';
+import { CAID_FACETS_WGD } from 'shared/constants';
 
 /**
  * @author Avery Wang
@@ -86,7 +87,7 @@ export function getWGD(
 ) {
     let wgdData = sampleIdToClinicalDataMap
         ? sampleIdToClinicalDataMap[sampleId].filter(
-              (cd: ClinicalData) => cd.clinicalAttributeId === 'FACETS_WGD'
+              (cd: ClinicalData) => cd.clinicalAttributeId === CAID_FACETS_WGD
           )
         : undefined;
     return wgdData !== undefined && wgdData.length > 0

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
@@ -3,6 +3,7 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { hasASCNProperty } from 'shared/lib/MutationUtils';
 import SampleManager from 'pages/patientView/SampleManager';
 import MutantCopiesElement from 'shared/components/mutationTable/column/mutantCopies/MutantCopiesElement';
+import { RV_NA } from 'shared/constants';
 
 /**
  * @author Avery Wang
@@ -92,13 +93,13 @@ export default class MutantCopiesColumnFormatter {
                 'totalCopyNumber'
             )
                 ? mutation.alleleSpecificCopyNumber.totalCopyNumber.toString()
-                : 'NA';
+                : RV_NA;
             sampleToMutantCopies[mutation.sampleId] = hasASCNProperty(
                 mutation,
                 'mutantCopies'
             )
                 ? mutation.alleleSpecificCopyNumber.mutantCopies.toString()
-                : 'NA';
+                : RV_NA;
         }
 
         // exclude samples with invalid count value (undefined || emtpy || lte 0)
@@ -106,8 +107,8 @@ export default class MutantCopiesColumnFormatter {
             sampleId =>
                 sampleToTotalCopyNumber[sampleId] &&
                 sampleToMutantCopies[sampleId] &&
-                sampleToTotalCopyNumber[sampleId] !== 'NA' &&
-                sampleToMutantCopies[sampleId] !== 'NA'
+                sampleToTotalCopyNumber[sampleId] !== RV_NA &&
+                sampleToMutantCopies[sampleId] !== RV_NA
         );
 
         return (

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,3 +2,48 @@ export const MOLECULAR_PROFILE_MUTATIONS_SUFFIX = '_mutations';
 export const MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX = `${MOLECULAR_PROFILE_MUTATIONS_SUFFIX}_uncalled`;
 export const MUTATION_STATUS_GERMLINE = 'Germline';
 export const PUTATIVE_DRIVER = 'Putative_Driver';
+
+export const SAMPLE_CANCER_TYPE_UNKNOWN = 'Unknown';
+
+/* cbioportal api request arguments */
+
+export const RARG_PROJECTION_META = 'META';
+export const RARG_PROJECTION_SUMMARY = 'SUMMARY';
+export const RARG_PROJECTION_DETAILED = 'DETAILED';
+export const RARG_CASE_TYPE_PATIENT = 'PATIENT';
+export const RARG_CASE_TYPE_SAMPLE = 'SAMPLE';
+export const RARG_CLINICAL_DATA_TYPE_PATIENT = 'PATIENT';
+export const RARG_CLINICAL_DATA_TYPE_SAMPLE = 'SAMPLE';
+
+/* cbioportal api responses */
+
+/* cbioportal api responses - general response values */
+export const RV_NA = 'NA';
+
+/* cbioportal api responses - clinical attribute identifiers */
+export const CAID_CANCER_TYPE = 'CANCER_TYPE';
+export const CAID_CANCER_TYPE_DETAILED = 'CANCER_TYPE_DETAILED';
+export const CAID_FACETS_PURITY = 'FACETS_PURITY';
+export const CAID_FACETS_WGD = 'FACETS_WGD';
+
+/* cbioportal api responses - clinical attribute fields and subfields */
+export const CAF_ID = 'clinicalAttributeId';
+export const CAF_DATATYPE_NUMBER = 'NUMBER';
+export const CAF_DATATYPE_STRING = 'STRING';
+export const CAF_DATATYPE_COUNTS_MAP = 'COUNTS_MAP';
+
+/* cbioportal api responses - mutation data fields and subfields */
+export const MDF_ASCN_INTEGER_COPY_NUMBER = 'ascnIntegerCopyNumber';
+export const MDF_TOTAL_COPY_NUMBER = 'totalCopyNumber';
+export const MDF_MINOR_COPY_NUMBER = 'minorCopyNumber';
+export const MDF_MUTANT_COPIES = 'mutantCopies';
+
+/* cbioportal api responses - genetic profile fields and subfields */
+export const GPF_MOLECULAR_ALTERATION_TYPE = 'molecularAlterationType';
+export const GPF_STUDY_ID = 'studyId';
+
+/* genome nexus api request arguments */
+export const GNARG_FIELD_ANNOTATION_SUMMARY = 'annotation_summary';
+export const GNARG_FIELD_HOTSPOTS = 'hotspots';
+export const GNARG_FIELD_MUTATION_ASSESSOR = 'mutation_assessor';
+export const GNARG_FIELD_MY_VARIANT_INFO = 'my_variant_info';


### PR DESCRIPTION
- new constants have globally unique names based on prefix:
    - CAF = clinical attribute field names/values
    - CAID = clinical attribute identifiers
    - GNARG_FIELD = genome nexus argument fields names
    - GPF = genetic/molecular profile field names
    - RARG = api request arguments