### PR TITLE
Add ASCNMethodColumnFormatter tests

### DIFF
--- a/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.spec.tsx
@@ -1,0 +1,48 @@
+import * as _ from 'lodash';
+import { ReactWrapper, mount } from 'enzyme';
+import { assert } from 'chai';
+import { initMutation } from 'test/MutationMockUtils';
+import { getDefaultASCNMethodColumnDefinition } from './ASCNMethodColumnFormatter';
+
+describe('ASCNMethodColumnFormatter', () => {
+    const mutationWithAscnData = initMutation({
+        sampleId: 'sample_with_ascn_data',
+        alleleSpecificCopyNumber: {
+            ascnMethod: 'my_ascn_method',
+        },
+    });
+    const mutationWithoutAscnData = initMutation({
+        sampleId: 'sample_without_ascn_data',
+    });
+
+    let componentWithAscnMethodColumn: ReactWrapper<any, any>;
+    let componentWithoutAscnMethodColumn: ReactWrapper<any, any>;
+
+    before(() => {
+        componentWithAscnMethodColumn = mount(
+            getDefaultASCNMethodColumnDefinition().render([
+                mutationWithAscnData,
+            ])
+        );
+        componentWithoutAscnMethodColumn = mount(
+            getDefaultASCNMethodColumnDefinition().render([
+                mutationWithoutAscnData,
+            ])
+        );
+    });
+
+    it('renders default ascn method column', () => {
+        assert.isTrue(
+            componentWithAscnMethodColumn
+                .find('span')
+                .text()
+                .indexOf('my_ascn_method') > -1,
+            'ASCN method should be defined for mutation with ASCN method available.'
+        );
+        assert.isTrue(
+            componentWithoutAscnMethodColumn.find('span').text().length == 0,
+            'ASCN method should be an empty string if not available for a mutation'
+        );
+    });
+    after(() => {});
+});

--- a/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { Mutation } from 'cbioportal-ts-api-client';
 import { hasASCNProperty } from 'shared/lib/MutationUtils';
-import SampleManager from 'pages/patientView/SampleManager';
 
 /**
  * @author Avery Wang
  */
 
-function getASCNMethodValue(mutation: Mutation): string {
+export function getASCNMethodValue(mutation: Mutation): string {
     return hasASCNProperty(mutation, 'ascnMethod')
         ? mutation.alleleSpecificCopyNumber.ascnMethod
         : '';

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
@@ -22,7 +22,7 @@ function getSampleIdToMutantCopiesMap(
     return sampleToValue;
 }
 
-function getDisplayValueAsString(
+export function getDisplayValueAsString(
     data: Mutation[],
     sampleIds: string[]
 ): string {


### PR DESCRIPTION
TODO:
- [x] ASCNMethodColumnFormatter.tsx
- [x] CancerCellFractionColumnFormatter.tsx // in progress (angelica)
- [ ] ClonalColumnFormatter.tsx
- [ ] MutantCopiesColumnFormatter.tsx
- [ ] ASCNCopyNumberColumnFormatter.tsx

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

Fix cBioPortal/cbioportal# (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- a
- b

# Checks
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
