### PR TITLE
Drop argument for passing sample clinical data

### DIFF
--- a/src/pages/resultsView/ResultsViewPage.tsx
+++ b/src/pages/resultsView/ResultsViewPage.tsx
@@ -267,9 +267,6 @@ export default class ResultsViewPage extends React.Component<
                             <Mutations
                                 store={store}
                                 appStore={this.props.appStore}
-                                sampleIdToClinicalDataMap={
-                                    store.clinicalDataGroupedBySampleMap.result
-                                }
                             />
                         </MSKTab>
                     );

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -2843,7 +2843,8 @@ export class ResultsViewPageStore {
                                     this.uniqueSampleKeyToTumorType.result!,
                                     this.generateGenomeNexusHgvsgUrl,
                                     this.genomeNexusClient,
-                                    this.genomeNexusInternalClient
+                                    this.genomeNexusInternalClient,
+                                    this.clinicalDataGroupedBySampleMap
                                 );
                                 return map;
                             },

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -19,7 +19,6 @@ export interface IMutationsPageProps {
     routing?: any;
     store: ResultsViewPageStore;
     appStore: AppStore;
-    sampleIdToClinicalDataMap: {};
 }
 
 @observer
@@ -164,7 +163,6 @@ export default class Mutations extends React.Component<
                             generateGenomeNexusHgvsgUrl={
                                 this.props.store.generateGenomeNexusHgvsgUrl
                             }
-                            clinicalDataStore={this.props.store}
                         />
                     </MSKTab>
                 );

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -29,7 +29,6 @@ export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     mutationCountCache?: MutationCountCache;
     genomeNexusMyVariantInfoCache?: GenomeNexusMyVariantInfoCache;
     userEmailAddress: string;
-    clinicalDataStore: ResultsViewPageStore;
 }
 
 @observer
@@ -79,7 +78,8 @@ export default class ResultsViewMutationMapper extends MutationMapper<
             getMobxPromiseGroupStatus(
                 this.props.store.clinicalDataForSamples,
                 this.props.store.studiesForSamplesWithoutCancerTypeClinicalData,
-                this.props.store.canonicalTranscript
+                this.props.store.canonicalTranscript,
+                this.props.store.clinicalDataGroupedBySampleMap
             ) === 'pending'
         );
     }
@@ -143,8 +143,7 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                     this.props.store.generateGenomeNexusHgvsgUrl
                 }
                 sampleIdToClinicalDataMap={
-                    this.props.clinicalDataStore.clinicalDataGroupedBySampleMap
-                        .result
+                    this.props.store.clinicalDataGroupedBySampleMap.result
                 }
             />
         );

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapperStore.ts
@@ -68,7 +68,10 @@ export default class ResultsViewMutationMapperStore extends MutationMapperStore 
         },
         public generateGenomeNexusHgvsgUrl: (hgvsg: string) => string,
         protected genomenexusClient?: GenomeNexusAPI,
-        protected genomenexusInternalClient?: GenomeNexusAPIInternal
+        protected genomenexusInternalClient?: GenomeNexusAPIInternal,
+        public clinicalDataGroupedBySampleMap: MobxPromise<{
+            [sampleId: string]: ClinicalData[];
+        }>
     ) {
         super(
             mutationMapperConfig,

--- a/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
+++ b/src/pages/staticPages/tools/mutationMapper/StandaloneMutationTable.tsx
@@ -43,8 +43,6 @@ export default class StandaloneMutationTable extends MutationTable<
             MutationTableColumnType.PROTEIN_CHANGE,
             MutationTableColumnType.MUTATION_TYPE,
             MutationTableColumnType.VARIANT_TYPE,
-            MutationTableColumnType.CLONAL,
-            MutationTableColumnType.MUTANT_COPIES,
             MutationTableColumnType.TUMOR_ALLELE_FREQ,
             MutationTableColumnType.NORMAL_ALLELE_FREQ,
             MutationTableColumnType.EXON,
@@ -86,8 +84,6 @@ export default class StandaloneMutationTable extends MutationTable<
         this._columns[MutationTableColumnType.FUNCTIONAL_IMPACT].order = 38;
         this._columns[MutationTableColumnType.MUTATION_TYPE].order = 40;
         this._columns[MutationTableColumnType.VARIANT_TYPE].order = 45;
-        this._columns[MutationTableColumnType.CLONAL].order = 46;
-        this._columns[MutationTableColumnType.MUTANT_COPIES].order = 47;
         //this._columns[MutationTableColumnType.COPY_NUM].order = 50;
         //this._columns[MutationTableColumnType.COSMIC].order = 60;
         this._columns[MutationTableColumnType.MUTATION_STATUS].order = 70;


### PR DESCRIPTION
- move to store returned by function
- continue to pass down property from MutationMapper element
Revert StandaloneMutationMapper (does not parse facets fields)
