### PR TITLE
Some fixes

### DIFF
--- a/src/pages/patientView/clinicalInformation/ClinicalInformationMutationalSignatureTable.spec.tsx
+++ b/src/pages/patientView/clinicalInformation/ClinicalInformationMutationalSignatureTable.spec.tsx
@@ -42,9 +42,6 @@ const sampleMutationalSignatureData = [
 ];
 
 describe('ClinicalInformationMutationalSignatureTable', () => {
-    before(() => {});
-    after(() => {});
-
     it('takes mutational signature sample data and formats it for mutational signature table to render', () => {
         let result = prepareMutationalSignatureDataForTable(
             sampleMutationalSignatureData

--- a/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/AnnotationColumnFormatter.spec.tsx
@@ -12,10 +12,6 @@ import {
 } from 'test/CivicMockUtils';
 
 describe('AnnotationColumnFormatter', () => {
-    before(() => {});
-
-    after(() => {});
-
     it('properly creates a civic entry', () => {
         let civicGenes = getCivicGenes();
 

--- a/src/pages/patientView/copyNumberAlterations/column/CnaColumnFormatter.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/CnaColumnFormatter.spec.tsx
@@ -9,10 +9,6 @@ import sinon from 'sinon';
 import { DiscreteCopyNumberData } from 'cbioportal-ts-api-client';
 
 describe('CnaColumnFormatter', () => {
-    before(() => {});
-
-    after(() => {});
-
     it('CNA column renderer shows correct text based on alteration value', () => {
         let output = mount(
             CnaColumnFormatter.renderFunction([

--- a/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.spec.tsx
+++ b/src/pages/patientView/copyNumberAlterations/column/CohortColumnFormatter.spec.tsx
@@ -189,6 +189,4 @@ describe('CohortColumnFormatter', () => {
         assert.equal(qValue, 0.00045);
         assert.equal(count, 4);
     });
-
-    after(() => {});
 });

--- a/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/AlleleFreqColumnFormatter.spec.tsx
@@ -11,10 +11,6 @@ import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 describe('AlleleFreqColumnFormatter', () => {
-    before(() => {});
-
-    after(() => {});
-
     it('uncalled mutations component w/o reads should have 0 opacity', () => {
         const uncalledMutationWithoutSupport = {
             molecularProfileId: `study_${MOLECULAR_PROFILE_UNCALLED_MUTATIONS_SUFFIX}`,

--- a/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.tsx
+++ b/src/pages/patientView/mutation/column/TumorColumnFormatter.spec.tsx
@@ -24,10 +24,6 @@ describe('TumorColumnFormatter', () => {
         },
     ];
 
-    before(() => {});
-
-    after(() => {});
-
     it('test get present samples', () => {
         let presentSamples = TumorColumnFormatter.getPresentSamples(testData);
         assert(presentSamples['A'], 'sample A is present and is called');

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -194,26 +194,12 @@ import ComplexKeySet from '../../shared/lib/complexKeyDataStructures/ComplexKeyS
 import { createVariantAnnotationsByMutationFetcher } from 'shared/components/mutationMapper/MutationMapperUtils';
 import { getGenomeNexusHgvsgUrl } from 'shared/api/urls';
 import {
-    CAF_DATATYPE_COUNTS_MAP,
-    CAF_DATATYPE_NUMBER,
-    CAF_DATATYPE_STRING,
-    CAF_ID,
-    CAID_CANCER_TYPE,
-    CAID_CANCER_TYPE_DETAILED,
-    CAID_FACETS_PURITY,
-    CAID_FACETS_WGD,
-    GNARG_FIELD_ANNOTATION_SUMMARY,
-    GNARG_FIELD_HOTSPOTS,
-    GNARG_FIELD_MUTATION_ASSESSOR,
-    GNARG_FIELD_MY_VARIANT_INFO,
-    GPF_MOLECULAR_ALTERATION_TYPE,
-    GPF_STUDY_ID,
+    CLINICAL_ATTRIBUTE_FIELD_ENUM,
+    CLINICAL_ATTRIBUTE_ID_ENUM,
+    GENOME_NEXUS_ARG_FIELD_ENUM,
+    GENETIC_PROFILE_FIELD_ENUM,
     PUTATIVE_DRIVER,
-    RARG_CLINICAL_DATA_TYPE_PATIENT,
-    RARG_CLINICAL_DATA_TYPE_SAMPLE,
-    RARG_PROJECTION_DETAILED,
-    RARG_PROJECTION_META,
-    RARG_PROJECTION_SUMMARY,
+    REQUEST_ARG_ENUM,
     SAMPLE_CANCER_TYPE_UNKNOWN,
 } from 'shared/constants';
 
@@ -391,10 +377,10 @@ export function extendSamplesWithCancerType(
         if (clinicalData) {
             clinicalData.forEach((clinicalDatum: ClinicalData) => {
                 switch (clinicalDatum.clinicalAttributeId) {
-                    case CAID_CANCER_TYPE_DETAILED:
+                    case CLINICAL_ATTRIBUTE_ID_ENUM.CANCER_TYPE_DETAILED:
                         sample.cancerTypeDetailed = clinicalDatum.value;
                         break;
-                    case CAID_CANCER_TYPE:
+                    case CLINICAL_ATTRIBUTE_ID_ENUM.CANCER_TYPE:
                         sample.cancerType = clinicalDatum.value;
                         break;
                     default:
@@ -858,7 +844,10 @@ export class ResultsViewPageStore {
             const profiles: MolecularProfile[] = this.selectedMolecularProfiles
                 .result!;
             return Promise.resolve(
-                _.groupBy(profiles, GPF_MOLECULAR_ALTERATION_TYPE)
+                _.groupBy(
+                    profiles,
+                    GENETIC_PROFILE_FIELD_ENUM.MOLECULAR_ALTERATION_TYPE
+                )
             );
         },
     });
@@ -882,7 +871,7 @@ export class ResultsViewPageStore {
             const specialAttributes = [
                 {
                     clinicalAttributeId: SpecialAttribute.MutationSpectrum,
-                    datatype: CAF_DATATYPE_COUNTS_MAP,
+                    datatype: CLINICAL_ATTRIBUTE_FIELD_ENUM.DATATYPE_COUNTS_MAP,
                     description:
                         'Number of point mutations in the sample counted by different types of nucleotide changes.',
                     displayName: 'Mutation spectrum',
@@ -895,7 +884,7 @@ export class ResultsViewPageStore {
                 // if more than one study, add "Study of Origin" attribute
                 specialAttributes.push({
                     clinicalAttributeId: SpecialAttribute.StudyOfOrigin,
-                    datatype: CAF_DATATYPE_STRING,
+                    datatype: CLINICAL_ATTRIBUTE_FIELD_ENUM.DATATYPE_STRING,
                     description: 'Study which the sample is a part of.',
                     displayName: 'Study of origin',
                     patientAttribute: false,
@@ -907,7 +896,7 @@ export class ResultsViewPageStore {
                 // if different number of samples and patients, add "Num Samples of Patient" attribute
                 specialAttributes.push({
                     clinicalAttributeId: SpecialAttribute.NumSamplesPerPatient,
-                    datatype: CAF_DATATYPE_NUMBER,
+                    datatype: CLINICAL_ATTRIBUTE_FIELD_ENUM.DATATYPE_NUMBER,
                     description: 'Number of queried samples for each patient.',
                     displayName: '# Samples per Patient',
                     patientAttribute: true,
@@ -925,7 +914,12 @@ export class ResultsViewPageStore {
     readonly clinicalAttributeIdToClinicalAttribute = remoteData({
         await: () => [this.clinicalAttributes],
         invoke: () =>
-            Promise.resolve(_.keyBy(this.clinicalAttributes.result!, CAF_ID)),
+            Promise.resolve(
+                _.keyBy(
+                    this.clinicalAttributes.result!,
+                    CLINICAL_ATTRIBUTE_FIELD_ENUM.ID
+                )
+            ),
     });
 
     readonly clinicalAttributeIdToAvailableSampleCount = remoteData({
@@ -1105,7 +1099,7 @@ export class ResultsViewPageStore {
                 if (identifiers.length) {
                     return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
                         {
-                            projection: RARG_PROJECTION_DETAILED,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                             molecularDataMultipleStudyFilter: {
                                 entrezGeneIds: _.map(
                                     this.genes.result,
@@ -1174,7 +1168,7 @@ export class ResultsViewPageStore {
                 if (sampleIdentifiers.length) {
                     return client.fetchMolecularDataInMultipleMolecularProfilesUsingPOST(
                         {
-                            projection: RARG_PROJECTION_DETAILED,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                             molecularDataMultipleStudyFilter: {
                                 entrezGeneIds: _.map(
                                     this.genes.result,
@@ -1219,7 +1213,7 @@ export class ResultsViewPageStore {
             );
             const studyToProfiles = _.groupBy(
                 coExpressionProfiles,
-                GPF_STUDY_ID
+                GENETIC_PROFILE_FIELD_ENUM.STUDY_ID
             );
             // we know these are all mrna and protein profiles
             const sampleMolecularIdentifiers = _.flatten(
@@ -1247,7 +1241,7 @@ export class ResultsViewPageStore {
                                 entrezGeneIds,
                                 sampleMolecularIdentifiers,
                             } as MolecularDataMultipleStudyFilter,
-                            projection: RARG_PROJECTION_META,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_META,
                         }
                     )
                     .then(function(response: request.Response) {
@@ -1330,7 +1324,7 @@ export class ResultsViewPageStore {
                 }
 
                 const molecularProfileId = profile.molecularProfileId;
-                const projection = RARG_PROJECTION_META;
+                const projection = REQUEST_ARG_ENUM.PROJECTION_META;
                 const dataFilter = {
                     entrezGeneIds: this.genes.result!.map(g => g.entrezGeneId),
                     ...dataQueryFilter,
@@ -1755,7 +1749,7 @@ export class ResultsViewPageStore {
                 if (genePanelIds.length) {
                     genePanels = await client.fetchGenePanelsUsingPOST({
                         genePanelIds,
-                        projection: RARG_PROJECTION_DETAILED,
+                        projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                     });
                 }
                 return computeGenePanelInformation(
@@ -2410,7 +2404,7 @@ export class ResultsViewPageStore {
                             sampleListIds: sampleListsToQuery.map(
                                 spec => spec.sampleListId
                             ),
-                            projection: RARG_PROJECTION_DETAILED,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                         }
                     );
                     // add samples from those sample lists to corresponding study
@@ -2488,7 +2482,7 @@ export class ResultsViewPageStore {
                     uniqueStudyIds.map(studyId => {
                         return client.getAllSampleListsInStudyUsingGET({
                             studyId: studyId,
-                            projection: RARG_PROJECTION_SUMMARY,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_SUMMARY,
                         });
                     })
                 );
@@ -2545,7 +2539,7 @@ export class ResultsViewPageStore {
         {
             invoke: async () =>
                 await client.getAllStudiesUsingGET({
-                    projection: RARG_PROJECTION_SUMMARY,
+                    projection: REQUEST_ARG_ENUM.PROJECTION_SUMMARY,
                 }),
         },
         []
@@ -2711,7 +2705,7 @@ export class ResultsViewPageStore {
 
             return await client.fetchMutationsInMultipleMolecularProfilesUsingPOST(
                 {
-                    projection: RARG_PROJECTION_DETAILED,
+                    projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                     mutationMultipleStudyFilter: data,
                 }
             );
@@ -2916,10 +2910,13 @@ export class ResultsViewPageStore {
             await: () => [this.studies, this.samples],
             invoke: () =>
                 this.getClinicalData(
-                    RARG_CLINICAL_DATA_TYPE_SAMPLE,
+                    REQUEST_ARG_ENUM.CLINICAL_DATA_TYPE_SAMPLE,
                     this.studies.result!,
                     this.samples.result,
-                    [CAID_CANCER_TYPE, CAID_CANCER_TYPE_DETAILED]
+                    [
+                        CLINICAL_ATTRIBUTE_ID_ENUM.CANCER_TYPE,
+                        CLINICAL_ATTRIBUTE_ID_ENUM.CANCER_TYPE_DETAILED,
+                    ]
                 ),
         },
         []
@@ -2930,10 +2927,13 @@ export class ResultsViewPageStore {
             await: () => [this.studies, this.samples],
             invoke: () =>
                 this.getClinicalData(
-                    RARG_CLINICAL_DATA_TYPE_SAMPLE,
+                    REQUEST_ARG_ENUM.CLINICAL_DATA_TYPE_SAMPLE,
                     this.studies.result!,
                     this.samples.result,
-                    [CAID_FACETS_WGD, CAID_FACETS_PURITY]
+                    [
+                        CLINICAL_ATTRIBUTE_ID_ENUM.FACETS_WGD,
+                        CLINICAL_ATTRIBUTE_ID_ENUM.FACETS_PURITY,
+                    ]
                 ),
         },
         []
@@ -3013,7 +3013,7 @@ export class ResultsViewPageStore {
         entities: any[],
         attributeIds: string[]
     ): Promise<number> {
-        const projection = RARG_PROJECTION_META;
+        const projection = REQUEST_ARG_ENUM.PROJECTION_META;
         // single study query endpoint is optimal so we should use it
         // when there's only one study
         if (studies.length === 1) {
@@ -3072,7 +3072,7 @@ export class ResultsViewPageStore {
         invoke: async () => {
             if (!_.isEmpty(this.survivalClinicalDataAttributes.result)) {
                 const count = await this.getClinicalDataCount(
-                    RARG_CLINICAL_DATA_TYPE_PATIENT,
+                    REQUEST_ARG_ENUM.CLINICAL_DATA_TYPE_PATIENT,
                     this.studies.result!,
                     this.patients.result,
                     this.survivalClinicalDataAttributes.result!
@@ -3093,7 +3093,7 @@ export class ResultsViewPageStore {
             invoke: () => {
                 if (!_.isEmpty(this.survivalClinicalDataAttributes.result)) {
                     return this.getClinicalData(
-                        RARG_CLINICAL_DATA_TYPE_PATIENT,
+                        REQUEST_ARG_ENUM.CLINICAL_DATA_TYPE_PATIENT,
                         this.studies.result!,
                         this.patients.result,
                         this.survivalClinicalDataAttributes.result!
@@ -3158,7 +3158,7 @@ export class ResultsViewPageStore {
                             sampleFilter: {
                                 sampleIdentifiers,
                             } as SampleFilter,
-                            projection: RARG_PROJECTION_DETAILED,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                         })
                     );
                 }
@@ -3168,7 +3168,7 @@ export class ResultsViewPageStore {
                             sampleFilter: {
                                 sampleListIds,
                             } as SampleFilter,
-                            projection: RARG_PROJECTION_DETAILED,
+                            projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                         })
                     );
                 }
@@ -3270,7 +3270,7 @@ export class ResultsViewPageStore {
             invoke: async () => {
                 return client.fetchStudiesUsingPOST({
                     studyIds: this.studyIds.result!,
-                    projection: RARG_PROJECTION_DETAILED,
+                    projection: REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                 });
             },
         },
@@ -4099,8 +4099,8 @@ export class ResultsViewPageStore {
                     ? await fetchVariantAnnotationsIndexedByGenomicLocation(
                           this.mutations.result,
                           [
-                              GNARG_FIELD_ANNOTATION_SUMMARY,
-                              GNARG_FIELD_HOTSPOTS,
+                              GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                              GENOME_NEXUS_ARG_FIELD_ENUM.HOTSPOTS,
                           ],
                           AppConfig.serverConfig.isoformOverrideSource,
                           this.genomeNexusClient
@@ -4450,7 +4450,7 @@ export class ResultsViewPageStore {
     @cached get genomeNexusCache() {
         return new GenomeNexusCache(
             createVariantAnnotationsByMutationFetcher(
-                [GNARG_FIELD_ANNOTATION_SUMMARY],
+                [GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY],
                 this.genomeNexusClient
             )
         );
@@ -4459,7 +4459,10 @@ export class ResultsViewPageStore {
     @cached get genomeNexusMutationAssessorCache() {
         return new GenomeNexusMutationAssessorCache(
             createVariantAnnotationsByMutationFetcher(
-                [GNARG_FIELD_ANNOTATION_SUMMARY, GNARG_FIELD_MUTATION_ASSESSOR],
+                [
+                    GENOME_NEXUS_ARG_FIELD_ENUM.ANNOTATION_SUMMARY,
+                    GENOME_NEXUS_ARG_FIELD_ENUM.MUTATION_ASSESSOR,
+                ],
                 this.genomeNexusClient
             )
         );
@@ -4468,7 +4471,7 @@ export class ResultsViewPageStore {
     @cached get genomeNexusMyVariantInfoCache() {
         return new GenomeNexusMyVariantInfoCache(
             createVariantAnnotationsByMutationFetcher(
-                [GNARG_FIELD_MY_VARIANT_INFO],
+                [GENOME_NEXUS_ARG_FIELD_ENUM.MY_VARIANT_INFO],
                 this.genomeNexusClient
             )
         );
@@ -4656,7 +4659,8 @@ export class ResultsViewPageStore {
                                         entrezGeneIds: [q.entrezGeneId],
                                         ...dqf,
                                     } as MutationFilter,
-                                    projection: RARG_PROJECTION_DETAILED,
+                                    projection:
+                                        REQUEST_ARG_ENUM.PROJECTION_DETAILED,
                                 }
                             );
                         } else {

--- a/src/shared/components/MSKTabs/MSKTabs.spec.tsx
+++ b/src/shared/components/MSKTabs/MSKTabs.spec.tsx
@@ -31,8 +31,6 @@ describe('MSKTabs', () => {
         tabs.update();
     });
 
-    after(() => {});
-
     it('initial render only mounts first tab', done => {
         setTimeout(function() {
             assert.equal(tabs.update().find('.msk-tab').length, 1);

--- a/src/shared/components/cohort/FrequencyBar.spec.tsx
+++ b/src/shared/components/cohort/FrequencyBar.spec.tsx
@@ -95,6 +95,4 @@ describe('FrequencyBar', () => {
             'component should have a tooltip'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.spec.tsx
+++ b/src/shared/components/columnVisibilityControls/ColumnVisibilityControls.spec.tsx
@@ -10,8 +10,6 @@ import {
 describe('ColumnVisibilityControls', () => {
     beforeEach(() => {});
 
-    after(() => {});
-
     it('does not render list item if togglabe is false', () => {
         var cols: IColumnVisibilityDef[] = [
             {

--- a/src/shared/components/copyDownloadControls/CopyDownloadControls.spec.tsx
+++ b/src/shared/components/copyDownloadControls/CopyDownloadControls.spec.tsx
@@ -18,10 +18,6 @@ describe('CopyDownloadControls', () => {
         text: 'This data is incomplete, because sometimes shift happens!',
     };
 
-    before(() => {});
-
-    after(() => {});
-
     it('downloads the complete data without any error messages', done => {
         const resolvedPromiseWithCompleteData = Promise.resolve(completeData);
         const downloadData = () => resolvedPromiseWithCompleteData;

--- a/src/shared/components/mutationTable/column/AlleleCountColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/AlleleCountColumnFormatter.spec.tsx
@@ -7,10 +7,6 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { initMutation } from 'test/MutationMockUtils';
 
 describe('AlleleCountColumnFormatter', () => {
-    before(() => {});
-
-    after(() => {});
-
     it('ignores invalid allele count values', () => {
         const samples = [
             'SAMPLE1',

--- a/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/CosmicColumnFormatter.spec.tsx
@@ -153,6 +153,4 @@ describe('CosmicColumnFormatter', () => {
             'Sort value value property for DIABLO mutation should be null, no cosmic data'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/GeneColumnFormatter.spec.tsx
@@ -31,6 +31,4 @@ describe('GeneColumnFormatter', () => {
             'Gene symbol display value is correct'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.spec.tsx
@@ -39,8 +39,6 @@ describe('MutationStatusColumnFormatter', () => {
         );
     });
 
-    after(() => {});
-
     it('gets mutation status data properly', () => {
         assert.equal(
             MutationStatusColumnFormatter.getData(germlineData),

--- a/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/MutationTypeColumnFormatter.spec.tsx
@@ -176,6 +176,4 @@ describe('MutationTypeColumnFormatter', () => {
             'Other'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/SampleColumnFormatter.spec.tsx
@@ -60,6 +60,4 @@ describe('SampleColumnFormatter', () => {
             'Tooltip should exists for long sample id'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/ValidationStatusColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ValidationStatusColumnFormatter.spec.tsx
@@ -48,8 +48,6 @@ describe('MutationStatusColumnFormatter', () => {
         );
     });
 
-    after(() => {});
-
     it('gets validation status data properly', () => {
         assert.equal(
             ValidationStatusColumnFormatter.getData(validData),

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
@@ -4,7 +4,7 @@ import { assert, expect } from 'chai';
 import { Mutation, ClinicalData } from 'cbioportal-ts-api-client';
 import { initMutation } from 'test/MutationMockUtils';
 import { initClinicalData } from 'test/ClinicalDataMockUtils';
-import { CAID_FACETS_WGD } from 'shared/constants';
+import { CLINICAL_ATTRIBUTE_ID_ENUM } from 'shared/constants';
 import SampleManager from 'pages/patientView/SampleManager';
 import {
     ASCN_AMP,
@@ -244,11 +244,11 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         value: sample6Id,
     });
     const clinicalDataWgd: ClinicalData = initClinicalData({
-        clinicalAttributeId: CAID_FACETS_WGD,
+        clinicalAttributeId: CLINICAL_ATTRIBUTE_ID_ENUM.FACETS_WGD,
         value: 'WGD',
     });
     const clinicalDataNoWgd: ClinicalData = initClinicalData({
-        clinicalAttributeId: CAID_FACETS_WGD,
+        clinicalAttributeId: CLINICAL_ATTRIBUTE_ID_ENUM.FACETS_WGD,
         value: 'NO_WGD',
     });
     const s1NoWgdClinicalDataMap: {

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
@@ -34,26 +34,26 @@ import { getDefaultASCNCopyNumberColumnDefinition } from './ASCNCopyNumberColumn
                     attribute 'FACETS_WGD' containing a value "WGD" (and not "NO_WGD")
         - a hoverover tooltip showing one line per sample having the variant, each line with
             - a sample number icon using black SVG circle with superimposed white numeral
-            - a text label (e.g. "diploid") corresponding to the ASCNCopyNumberValue
+            - a text label (e.g. "diploid") corresponding to the ASCNCopyNumberValueEnum
             - text indication of presence/absence of WGD clinical attribute
             - text reporting of TOTAL_COPY_NUMBER and MINOR_COPY_NUMBER mutation attribute values
 
     test cases explore various expected combinations of the above elements:
         - cases involving only a single sample:
             - without any set ASCN mutation attriubutes
-            - with NO_WGD and ASCNCopyNumberValue from each of {'-2','-1','0','1','2','999','NA'}
-            - with WGD and ASCNCopyNumberValue from each of {see_above}
-            - with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '2'
-            - with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '2'
+            - with NO_WGD and ASCNCopyNumberValueEnum from each of {'-2','-1','0','1','2','999','NA'}
+            - with WGD and ASCNCopyNumberValueEnum from each of {see_above}
+            - with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '2'
+            - with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '2'
         - cases involving two samples:
             - without any set ASCN mutation attriubutes
-            - sample1 NO_WGD, ASCNCopyNumberValue from each of {see_above}; sample2 NO_WGD, ASCN_AMP
-            - sample1 NO_WGD, ASCN_HOMDEL; sample2 NO_WGD, ASCNCopyNumberValue from each of {see_above}
+            - sample1 NO_WGD, ASCNCopyNumberValueEnum from each of {see_above}; sample2 NO_WGD, ASCN_AMP
+            - sample1 NO_WGD, ASCN_HOMDEL; sample2 NO_WGD, ASCNCopyNumberValueEnum from each of {see_above}
             - sample1 NO_WGD, ASCN_HETLOSS; sample2 WGD, ASCN_GAIN
             - sample1 WGD, ASCN_HOMDEL; sample2 NO_WGD, ASCN_GAIN
             - sample1 WGD, ASCN_LIGHTGREY [0]; sample2 WGD, ASCN_BLACK [999]
-            - sample1 and sample 2 with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '-1'
-            - sample1 and sample 2 with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '-1'
+            - sample1 and sample 2 with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '-1'
+            - sample1 and sample 2 with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '-1'
         - cases involving three samples:
             - sample1 WGD, ASCN_AMP; sample2 NO_WGD, ASCN_LIGHTGREY; sample3 WGD, ASCN_HOMDEL
 
@@ -381,8 +381,6 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         nullSampleManager
     );
 
-    before(() => {});
-
     // Single sample tests - without any set ASCN mutation attriubutes
     it('renders default (no ASCN data) sample6', () => {
         const cellWrapper = mount(s6ColDef.render(mutations_s6));
@@ -393,7 +391,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s1Wrapper, 'NA', '-1', '-1', '-1');
     });
-    // Single sample tests - with NO_WGD and ASCNCopyNumberValue from each of {'-2','-1','0','1','2','999','NA'}
+    // Single sample tests - with NO_WGD and ASCNCopyNumberValueEnum from each of {'-2','-1','0','1','2','999','NA'}
     it('renders sample1 NoWgd Amp', () => {
         const cellWrapper = mount(s1NoWgdColDef.render(mutations_s1Amp));
         const elementsWrapper = cellWrapper.find('ASCNCopyNumberElement');
@@ -457,7 +455,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s1Wrapper, 'NO_WGD', '1', '1', 'NA');
     });
-    // Single sample tests - with WGD and ASCNCopyNumberValue from each of {see_above}
+    // Single sample tests - with WGD and ASCNCopyNumberValueEnum from each of {see_above}
     it('renders sample1 Wgd Amp', () => {
         const cellWrapper = mount(s1WgdColDef.render(mutations_s1Amp));
         const elementsWrapper = cellWrapper.find('ASCNCopyNumberElement');
@@ -521,7 +519,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s1Wrapper, 'WGD', '1', '1', 'NA');
     });
-    // Single sample tests - with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '2'
+    // Single sample tests - with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '2'
     it('renders sample1 NoWgd Amp totalCopy1', () => {
         const cellWrapper = mount(s1NoWgdColDef.render(mutations_s1Amp_TCN1));
         const elementsWrapper = cellWrapper.find('ASCNCopyNumberElement');
@@ -540,7 +538,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s1Wrapper, 'NO_WGD', '2', '1', '2');
     });
-    // Single sample tests - with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '2'
+    // Single sample tests - with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '2'
     it('renders sample1 Wgd Amp totalCopy1', () => {
         const cellWrapper = mount(s1WgdColDef.render(mutations_s1Amp_TCN1));
         const elementsWrapper = cellWrapper.find('ASCNCopyNumberElement');
@@ -573,7 +571,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s7Wrapper, 'NA', '-1', '-1', '-1'); // unset
     });
-    // Two sample tests - sample1 NO_WGD, ASCNCopyNumberValue from each of {see_above}; sample2 NO_WGD, ASCN_AMP
+    // Two sample tests - sample1 NO_WGD, ASCNCopyNumberValueEnum from each of {see_above}; sample2 NO_WGD, ASCN_AMP
     it('renders sample1 NoWgd Amp, sample2 NoWgd Amp', () => {
         const cellWrapper = mount(
             s1NoWgds2NoWgdColDef.render(mutations_s1Amp_s2Amp)
@@ -679,7 +677,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s2Wrapper, 'NO_WGD', '1', '1', '2');
     });
-    // Two sample tests - sample1 NO_WGD, ASCN_HOMDEL; sample2 NO_WGD, ASCNCopyNumberValue from each of {see_above}
+    // Two sample tests - sample1 NO_WGD, ASCN_HOMDEL; sample2 NO_WGD, ASCNCopyNumberValueEnum from each of {see_above}
     it('renders sample1 NoWgd Homdel, sample2 NoWgd Amp', () => {
         const cellWrapper = mount(
             s1NoWgds2NoWgdColDef.render(mutations_s1Homdel_s2Amp)
@@ -833,7 +831,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s2Wrapper, 'WGD', '1', '1', '999');
     });
-    // Two sample tests - sample1 and sample 2 with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '-1'
+    // Two sample tests - sample1 and sample 2 with NO_WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '-1'
     it('renders sample1 NoWgd Hetloss, sample2 NoWgd Hetloss totalCopy2', () => {
         const cellWrapper = mount(
             s1NoWgds2NoWgdColDef.render(mutations_s1Hetloss_s2Hetloss_TCN2)
@@ -879,7 +877,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s2Wrapper, 'NO_WGD', '2', '1', '-1');
     });
-    // Two sample tests - sample1 and sample 2 with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValue of '-1'
+    // Two sample tests - sample1 and sample 2 with WGD and TotalCopyNumber of either '1' or '2' and ASCNCopyNumberValueEnum of '-1'
     it('renders sample1 Wgd Hetloss, sample2 Wgd Hetloss totalCopy2', () => {
         const cellWrapper = mount(
             s1Wgds2WgdColDef.render(mutations_s1Hetloss_s2Hetloss_TCN2)
@@ -946,6 +944,4 @@ describe('ASCNCopyNumberColumnFormatter', () => {
         );
         expectElementPropertiesMatch(s3Wrapper, 'WGD', '1', '1', '-2');
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
@@ -7,7 +7,10 @@ import ASCNCopyNumberElement from 'shared/components/mutationTable/column/ascnCo
 import { ASCNCopyNumberValueEnum } from 'shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement';
 import { ASCN_BLACK } from 'shared/lib/Colors';
 import { getASCNCopyNumberColor } from 'shared/lib/ASCNUtils';
-import { CAID_FACETS_WGD } from 'shared/constants';
+import {
+    CLINICAL_ATTRIBUTE_ID_ENUM,
+    MUTATION_DATA_FIELD_ENUM,
+} from 'shared/constants';
 
 /**
  * @author Avery Wang
@@ -20,7 +23,10 @@ function getAscnCopyNumberData(
         | { [sampleId: string]: ClinicalData[] }
         | undefined
 ) {
-    return hasASCNProperty(mutation, 'ascnIntegerCopyNumber')
+    return hasASCNProperty(
+        mutation,
+        MUTATION_DATA_FIELD_ENUM.ASCN_INTEGER_COPY_NUMBER
+    )
         ? mutation.alleleSpecificCopyNumber.ascnIntegerCopyNumber
         : ASCNCopyNumberValueEnum.NA;
 }
@@ -85,7 +91,9 @@ export function getWGD(
 ) {
     let wgdData = sampleIdToClinicalDataMap
         ? sampleIdToClinicalDataMap[sampleId].find(
-              (cd: ClinicalData) => cd.clinicalAttributeId === CAID_FACETS_WGD
+              (cd: ClinicalData) =>
+                  cd.clinicalAttributeId ===
+                  CLINICAL_ATTRIBUTE_ID_ENUM.FACETS_WGD
           )
         : undefined;
     return wgdData !== undefined ? wgdData.value : ASCNCopyNumberValueEnum.NA;
@@ -145,7 +153,7 @@ export default class ASCNCopyNumberColumnFormatter {
                 : ASCNCopyNumberValueEnum.NA;
             sampleToASCNCopyNumber[mutation.sampleId] = hasASCNProperty(
                 mutation,
-                'ascnIntegerCopyNumber'
+                MUTATION_DATA_FIELD_ENUM.ASCN_INTEGER_COPY_NUMBER
             )
                 ? mutation.alleleSpecificCopyNumber.ascnIntegerCopyNumber.toString()
                 : ASCNCopyNumberValueEnum.NA;

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.tsx
@@ -4,7 +4,7 @@ import { Mutation, ClinicalData } from 'cbioportal-ts-api-client';
 import { hasASCNProperty } from 'shared/lib/MutationUtils';
 import SampleManager from 'pages/patientView/SampleManager';
 import ASCNCopyNumberElement from 'shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement';
-import { ASCNCopyNumberValue } from 'shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement';
+import { ASCNCopyNumberValueEnum } from 'shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement';
 import { ASCN_BLACK } from 'shared/lib/Colors';
 import { getASCNCopyNumberColor } from 'shared/lib/ASCNUtils';
 import { CAID_FACETS_WGD } from 'shared/constants';
@@ -22,7 +22,7 @@ function getAscnCopyNumberData(
 ) {
     return hasASCNProperty(mutation, 'ascnIntegerCopyNumber')
         ? mutation.alleleSpecificCopyNumber.ascnIntegerCopyNumber
-        : ASCNCopyNumberValue.NA;
+        : ASCNCopyNumberValueEnum.NA;
 }
 
 // sort by total copy number (since that is the number displayed in the icon
@@ -39,16 +39,16 @@ function getAllTotalCopyNumberForMutation(
                 sampleIdToClinicalDataMap
             );
             if (
-                ascnCopyNumberValue !== ASCNCopyNumberValue.NA &&
+                ascnCopyNumberValue !== ASCNCopyNumberValueEnum.NA &&
                 hasASCNProperty(mutation, 'totalCopyNumber') &&
                 getWGD(sampleIdToClinicalDataMap, mutation.sampleId) !==
-                    ASCNCopyNumberValue.NA &&
+                    ASCNCopyNumberValueEnum.NA &&
                 getASCNCopyNumberColor(ascnCopyNumberValue.toString()) !==
                     ASCN_BLACK
             ) {
                 return mutation.alleleSpecificCopyNumber.totalCopyNumber.toString();
             }
-            return ASCNCopyNumberValue.NA;
+            return ASCNCopyNumberValueEnum.NA;
         })
         .value();
     return sampleToCNA;
@@ -88,7 +88,7 @@ export function getWGD(
               (cd: ClinicalData) => cd.clinicalAttributeId === CAID_FACETS_WGD
           )
         : undefined;
-    return wgdData !== undefined ? wgdData.value : ASCNCopyNumberValue.NA;
+    return wgdData !== undefined ? wgdData.value : ASCNCopyNumberValueEnum.NA;
 }
 
 export const getDefaultASCNCopyNumberColumnDefinition = (
@@ -136,19 +136,19 @@ export default class ASCNCopyNumberColumnFormatter {
                 'totalCopyNumber'
             )
                 ? mutation.alleleSpecificCopyNumber.totalCopyNumber.toString()
-                : ASCNCopyNumberValue.NA;
+                : ASCNCopyNumberValueEnum.NA;
             sampleToMinorCopyNumber[mutation.sampleId] = hasASCNProperty(
                 mutation,
                 'minorCopyNumber'
             )
                 ? mutation.alleleSpecificCopyNumber.minorCopyNumber.toString()
-                : ASCNCopyNumberValue.NA;
+                : ASCNCopyNumberValueEnum.NA;
             sampleToASCNCopyNumber[mutation.sampleId] = hasASCNProperty(
                 mutation,
                 'ascnIntegerCopyNumber'
             )
                 ? mutation.alleleSpecificCopyNumber.ascnIntegerCopyNumber.toString()
-                : ASCNCopyNumberValue.NA;
+                : ASCNCopyNumberValueEnum.NA;
         }
 
         return (
@@ -168,17 +168,17 @@ export default class ASCNCopyNumberColumnFormatter {
                                 totalCopyNumberValue={
                                     sampleToTotalCopyNumber[sampleId]
                                         ? sampleToTotalCopyNumber[sampleId]
-                                        : ASCNCopyNumberValue.NA
+                                        : ASCNCopyNumberValueEnum.NA
                                 }
                                 minorCopyNumberValue={
                                     sampleToMinorCopyNumber[sampleId]
                                         ? sampleToMinorCopyNumber[sampleId]
-                                        : ASCNCopyNumberValue.NA
+                                        : ASCNCopyNumberValueEnum.NA
                                 }
                                 ascnCopyNumberValue={
                                     sampleToASCNCopyNumber[sampleId]
                                         ? sampleToASCNCopyNumber[sampleId]
-                                        : ASCNCopyNumberValue.NA
+                                        : ASCNCopyNumberValueEnum.NA
                                 }
                                 sampleManager={sampleManager}
                             />

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.spec.tsx
@@ -6,7 +6,7 @@ import SampleManager from 'pages/patientView/SampleManager';
 import {
     default as ASCNCopyNumberElement,
     ASCNCopyNumberElementTooltip,
-    ASCNCopyNumberValue,
+    ASCNCopyNumberValueEnum,
 } from './ASCNCopyNumberElement';
 import {
     ASCN_AMP,
@@ -37,7 +37,7 @@ import {
     - test wgd element (span) is not present when properties do not show WGD
 
     Test tooltip
-    - test ASCNCopyNumberValue text correct {Gain, Diploid, Double Loss After, ...}
+    - test ASCNCopyNumberValueEnum text correct {Gain, Diploid, Double Loss After, ...}
     - test "WGD"/"no WGD" text correct
     - test total copy number text correct "with total copy number of #"
     - test minor copy number text correct "and a minor copy number of #"
@@ -221,7 +221,7 @@ describe('ASCNCopyNumberElement', () => {
             </span>
         */
         const bElement = ascnCopyNumberElementTooltip.find('b');
-        expect(bElement).to.have.text(ASCNCopyNumberValue.NA);
+        expect(bElement).to.have.text(ASCNCopyNumberValueEnum.NA);
 
         const spanCount = countSpansWithCopyNumberText(
             ascnCopyNumberElementTooltip,
@@ -232,8 +232,6 @@ describe('ASCNCopyNumberElement', () => {
             "Expected zero 'span' elements containing specified values but failed"
         );
     }
-
-    before(() => {});
 
     it('ascn copy number of 2 should have the ASCN_AMP color and be visible', () => {
         let sample = initSample();
@@ -273,19 +271,19 @@ describe('ASCNCopyNumberElement', () => {
 
     it('total copy number of NA should have the ASCN_BLACK color and be invisible', () => {
         let sample = initSample();
-        sample.totalCopyNumberValue = ASCNCopyNumberValue.NA;
+        sample.totalCopyNumberValue = ASCNCopyNumberValueEnum.NA;
         testExpectedColorInvalidASCNCopyNumberElement(sample);
     });
 
     it('WGD of NA should have the ASCN_BLACK color and be invisible', () => {
         let sample = initSample();
-        sample.wgdValue = ASCNCopyNumberValue.NA;
+        sample.wgdValue = ASCNCopyNumberValueEnum.NA;
         testExpectedColorInvalidASCNCopyNumberElement(sample);
     });
 
     it('ascn copy number of NA should have the ASCN_BLACK color and be invisible', () => {
         let sample = initSample();
-        sample.ascnCopyNumberValue = ASCNCopyNumberValue.NA;
+        sample.ascnCopyNumberValue = ASCNCopyNumberValueEnum.NA;
         testExpectedColorInvalidASCNCopyNumberElement(sample);
     });
 
@@ -310,46 +308,46 @@ describe('ASCNCopyNumberElement', () => {
 
     it(
         'no wgd with major copy number of 1 and minor copy number of 0 displays ' +
-            ASCNCopyNumberValue.HETLOSS.toLowerCase() +
+            ASCNCopyNumberValueEnum.HETLOSS.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
             sample.wgdValue = 'no WGD';
             sample.totalCopyNumberValue = '1';
             sample.minorCopyNumberValue = '0';
-            testExpectedValidTooltip(sample, ASCNCopyNumberValue.HETLOSS);
+            testExpectedValidTooltip(sample, ASCNCopyNumberValueEnum.HETLOSS);
         }
     );
 
     it(
         'no wgd with major copy number of 1 and minor copy number of 1 displays ' +
-            ASCNCopyNumberValue.DIPLOID.toLowerCase() +
+            ASCNCopyNumberValueEnum.DIPLOID.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
             sample.wgdValue = 'no WGD';
             sample.totalCopyNumberValue = '2';
             sample.minorCopyNumberValue = '1';
-            testExpectedValidTooltip(sample, ASCNCopyNumberValue.DIPLOID);
+            testExpectedValidTooltip(sample, ASCNCopyNumberValueEnum.DIPLOID);
         }
     );
 
     it(
         'no wgd with major copy number of 2 and minor copy number of 1 displays ' +
-            ASCNCopyNumberValue.GAIN.toLowerCase() +
+            ASCNCopyNumberValueEnum.GAIN.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
             sample.wgdValue = 'no WGD';
             sample.totalCopyNumberValue = '3';
             sample.minorCopyNumberValue = '1';
-            testExpectedValidTooltip(sample, ASCNCopyNumberValue.GAIN);
+            testExpectedValidTooltip(sample, ASCNCopyNumberValueEnum.GAIN);
         }
     );
 
     it(
         'wgd with major copy number of 1 and minor copy number of 0 displays ' +
-            ASCNCopyNumberValue.LOSSBEFOREAFTER.toLowerCase() +
+            ASCNCopyNumberValueEnum.LOSSBEFOREAFTER.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
@@ -358,14 +356,14 @@ describe('ASCNCopyNumberElement', () => {
             sample.minorCopyNumberValue = '0';
             testExpectedValidTooltip(
                 sample,
-                ASCNCopyNumberValue.LOSSBEFOREAFTER
+                ASCNCopyNumberValueEnum.LOSSBEFOREAFTER
             );
         }
     );
 
     it(
         'wgd with major copy number of 1 and minor copy number of 1 displays ' +
-            ASCNCopyNumberValue.DOUBLELOSSAFTER.toLowerCase() +
+            ASCNCopyNumberValueEnum.DOUBLELOSSAFTER.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
@@ -374,35 +372,38 @@ describe('ASCNCopyNumberElement', () => {
             sample.minorCopyNumberValue = '1';
             testExpectedValidTooltip(
                 sample,
-                ASCNCopyNumberValue.DOUBLELOSSAFTER
+                ASCNCopyNumberValueEnum.DOUBLELOSSAFTER
             );
         }
     );
 
     it(
         'wgd with major copy number of 2 and minor copy number of 1 displays ' +
-            ASCNCopyNumberValue.LOSSAFTER.toLowerCase() +
+            ASCNCopyNumberValueEnum.LOSSAFTER.toLowerCase() +
             ' in tooltip',
         () => {
             let sample = initSample();
             sample.wgdValue = 'WGD';
             sample.totalCopyNumberValue = '3';
             sample.minorCopyNumberValue = '1';
-            testExpectedValidTooltip(sample, ASCNCopyNumberValue.LOSSAFTER);
+            testExpectedValidTooltip(sample, ASCNCopyNumberValueEnum.LOSSAFTER);
         }
     );
 
-    it('invalid wgd displays ' + ASCNCopyNumberValue.NA + ' in tooltip', () => {
-        let sample = initSample();
-        sample.wgdValue = 'not in table';
-        sample.totalCopyNumberValue = '3';
-        sample.minorCopyNumberValue = '1';
-        testExpectedInvalidTooltip(sample);
-    });
+    it(
+        'invalid wgd displays ' + ASCNCopyNumberValueEnum.NA + ' in tooltip',
+        () => {
+            let sample = initSample();
+            sample.wgdValue = 'not in table';
+            sample.totalCopyNumberValue = '3';
+            sample.minorCopyNumberValue = '1';
+            testExpectedInvalidTooltip(sample);
+        }
+    );
 
     it(
         'invalid major copy number displays ' +
-            ASCNCopyNumberValue.NA +
+            ASCNCopyNumberValueEnum.NA +
             ' in tooltip',
         () => {
             let sample = initSample();
@@ -415,7 +416,7 @@ describe('ASCNCopyNumberElement', () => {
 
     it(
         'invalid minor copy number displays ' +
-            ASCNCopyNumberValue.NA +
+            ASCNCopyNumberValueEnum.NA +
             ' in tooltip',
         () => {
             let sample = initSample();
@@ -425,6 +426,4 @@ describe('ASCNCopyNumberElement', () => {
             testExpectedInvalidTooltip(sample);
         }
     );
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.tsx
@@ -141,10 +141,7 @@ export const ASCNCopyNumberElementTooltip: React.FunctionComponent<{
                 <b>{ascnCopyNumberCall}</b>
                 {ascnCopyNumberCall !== ASCNCopyNumberValueEnum.NA ? (
                     <span>
-                        {' '}
-                        ({props.wgdValue} with total copy number of{' '}
-                        {props.totalCopyNumberValue} and a minor copy number of{' '}
-                        {props.minorCopyNumberValue})
+                        {` (${props.wgdValue} with total copy number of ${props.totalCopyNumberValue} and a minor copy number of ${props.minorCopyNumberValue})`}
                     </span>
                 ) : null}
             </span>

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberElement.tsx
@@ -4,7 +4,7 @@ import { DefaultTooltip } from 'cbioportal-frontend-commons';
 import { ASCN_BLACK } from 'shared/lib/Colors';
 import { getASCNCopyNumberColor } from 'shared/lib/ASCNUtils';
 
-export enum ASCNCopyNumberValue {
+export enum ASCNCopyNumberValueEnum {
     WGD = 'WGD',
     NA = 'NA',
     AMPBALANCED = 'Amp (Balanced)',
@@ -29,69 +29,69 @@ export enum ASCNCopyNumberValue {
 }
 
 const ASCNCallTable: { [key: string]: string } = {
-    'no WGD,0,0': ASCNCopyNumberValue.HOMDEL,
-    'no WGD,1,0': ASCNCopyNumberValue.HETLOSS,
-    'no WGD,2,0': ASCNCopyNumberValue.CNLOH,
-    'no WGD,3,0': ASCNCopyNumberValue.CNLOHGAIN,
-    'no WGD,4,0': ASCNCopyNumberValue.CNLOHGAIN,
-    'no WGD,5,0': ASCNCopyNumberValue.AMPLOH,
-    'no WGD,6,0': ASCNCopyNumberValue.AMPLOH,
-    'no WGD,1,1': ASCNCopyNumberValue.DIPLOID,
-    'no WGD,2,1': ASCNCopyNumberValue.GAIN,
-    'no WGD,3,1': ASCNCopyNumberValue.GAIN,
-    'no WGD,4,1': ASCNCopyNumberValue.AMP,
-    'no WGD,5,1': ASCNCopyNumberValue.AMP,
-    'no WGD,6,1': ASCNCopyNumberValue.AMP,
-    'no WGD,2,2': ASCNCopyNumberValue.TETRAPLOID,
-    'no WGD,3,2': ASCNCopyNumberValue.AMP,
-    'no WGD,4,2': ASCNCopyNumberValue.AMP,
-    'no WGD,5,2': ASCNCopyNumberValue.AMP,
-    'no WGD,6,2': ASCNCopyNumberValue.AMP,
-    'no WGD,3,3': ASCNCopyNumberValue.AMPBALANCED,
-    'no WGD,4,3': ASCNCopyNumberValue.AMP,
-    'no WGD,5,3': ASCNCopyNumberValue.AMP,
-    'no WGD,6,3': ASCNCopyNumberValue.AMP,
-    'WGD,0,0': ASCNCopyNumberValue.HOMDEL,
-    'WGD,1,0': ASCNCopyNumberValue.LOSSBEFOREAFTER,
-    'WGD,2,0': ASCNCopyNumberValue.LOSSBEFORE,
-    'WGD,3,0': ASCNCopyNumberValue.CNLOHBEFORELOSS,
-    'WGD,4,0': ASCNCopyNumberValue.CNLOHBEFORE,
-    'WGD,5,0': ASCNCopyNumberValue.CNLOHBEFOREGAIN,
-    'WGD,6,0': ASCNCopyNumberValue.AMPLOH,
-    'WGD,1,1': ASCNCopyNumberValue.DOUBLELOSSAFTER,
-    'WGD,2,1': ASCNCopyNumberValue.LOSSAFTER,
-    'WGD,3,1': ASCNCopyNumberValue.CNLOHAFTER,
-    'WGD,4,1': ASCNCopyNumberValue.LOSSGAIN,
-    'WGD,5,1': ASCNCopyNumberValue.AMP,
-    'WGD,6,1': ASCNCopyNumberValue.AMP,
-    'WGD,2,2': ASCNCopyNumberValue.TETRAPLOID,
-    'WGD,3,2': ASCNCopyNumberValue.GAIN,
-    'WGD,4,2': ASCNCopyNumberValue.AMP,
-    'WGD,5,2': ASCNCopyNumberValue.AMP,
-    'WGD,6,2': ASCNCopyNumberValue.AMP,
-    'WGD,3,3': ASCNCopyNumberValue.AMPBALANCED,
-    'WGD,4,3': ASCNCopyNumberValue.AMP,
-    'WGD,5,3': ASCNCopyNumberValue.AMP,
-    'WGD,6,3': ASCNCopyNumberValue.AMP,
+    'no WGD,0,0': ASCNCopyNumberValueEnum.HOMDEL,
+    'no WGD,1,0': ASCNCopyNumberValueEnum.HETLOSS,
+    'no WGD,2,0': ASCNCopyNumberValueEnum.CNLOH,
+    'no WGD,3,0': ASCNCopyNumberValueEnum.CNLOHGAIN,
+    'no WGD,4,0': ASCNCopyNumberValueEnum.CNLOHGAIN,
+    'no WGD,5,0': ASCNCopyNumberValueEnum.AMPLOH,
+    'no WGD,6,0': ASCNCopyNumberValueEnum.AMPLOH,
+    'no WGD,1,1': ASCNCopyNumberValueEnum.DIPLOID,
+    'no WGD,2,1': ASCNCopyNumberValueEnum.GAIN,
+    'no WGD,3,1': ASCNCopyNumberValueEnum.GAIN,
+    'no WGD,4,1': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,5,1': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,6,1': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,2,2': ASCNCopyNumberValueEnum.TETRAPLOID,
+    'no WGD,3,2': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,4,2': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,5,2': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,6,2': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,3,3': ASCNCopyNumberValueEnum.AMPBALANCED,
+    'no WGD,4,3': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,5,3': ASCNCopyNumberValueEnum.AMP,
+    'no WGD,6,3': ASCNCopyNumberValueEnum.AMP,
+    'WGD,0,0': ASCNCopyNumberValueEnum.HOMDEL,
+    'WGD,1,0': ASCNCopyNumberValueEnum.LOSSBEFOREAFTER,
+    'WGD,2,0': ASCNCopyNumberValueEnum.LOSSBEFORE,
+    'WGD,3,0': ASCNCopyNumberValueEnum.CNLOHBEFORELOSS,
+    'WGD,4,0': ASCNCopyNumberValueEnum.CNLOHBEFORE,
+    'WGD,5,0': ASCNCopyNumberValueEnum.CNLOHBEFOREGAIN,
+    'WGD,6,0': ASCNCopyNumberValueEnum.AMPLOH,
+    'WGD,1,1': ASCNCopyNumberValueEnum.DOUBLELOSSAFTER,
+    'WGD,2,1': ASCNCopyNumberValueEnum.LOSSAFTER,
+    'WGD,3,1': ASCNCopyNumberValueEnum.CNLOHAFTER,
+    'WGD,4,1': ASCNCopyNumberValueEnum.LOSSGAIN,
+    'WGD,5,1': ASCNCopyNumberValueEnum.AMP,
+    'WGD,6,1': ASCNCopyNumberValueEnum.AMP,
+    'WGD,2,2': ASCNCopyNumberValueEnum.TETRAPLOID,
+    'WGD,3,2': ASCNCopyNumberValueEnum.GAIN,
+    'WGD,4,2': ASCNCopyNumberValueEnum.AMP,
+    'WGD,5,2': ASCNCopyNumberValueEnum.AMP,
+    'WGD,6,2': ASCNCopyNumberValueEnum.AMP,
+    'WGD,3,3': ASCNCopyNumberValueEnum.AMPBALANCED,
+    'WGD,4,3': ASCNCopyNumberValueEnum.AMP,
+    'WGD,5,3': ASCNCopyNumberValueEnum.AMP,
+    'WGD,6,3': ASCNCopyNumberValueEnum.AMP,
 };
 
-enum ASCNCopyNumberOpacity {
+enum ASCNCopyNumberOpacityEnum {
     TRANSPARENT = 0,
     OPAQUE = 100,
 }
 
 function getASCNCopyNumberOpacity(
-    ASCNCopyNumberValue: string
-): ASCNCopyNumberOpacity {
-    switch (ASCNCopyNumberValue) {
+    ASCNCopyNumberValueEnum: string
+): ASCNCopyNumberOpacityEnum {
+    switch (ASCNCopyNumberValueEnum) {
         case '2':
         case '1':
         case '0':
         case '-1':
         case '-2':
-            return ASCNCopyNumberOpacity.OPAQUE;
+            return ASCNCopyNumberOpacityEnum.OPAQUE;
         default:
-            return ASCNCopyNumberOpacity.TRANSPARENT;
+            return ASCNCopyNumberOpacityEnum.TRANSPARENT;
     }
 }
 
@@ -110,7 +110,7 @@ function getASCNCopyNumberCall(
     ].join(',');
     return key in ASCNCallTable
         ? ASCNCallTable[key].toLowerCase()
-        : ASCNCopyNumberValue.NA;
+        : ASCNCopyNumberValueEnum.NA;
 }
 
 export const ASCNCopyNumberElementTooltip: React.FunctionComponent<{
@@ -139,7 +139,7 @@ export const ASCNCopyNumberElementTooltip: React.FunctionComponent<{
             ) : null}
             <span>
                 <b>{ascnCopyNumberCall}</b>
-                {ascnCopyNumberCall !== ASCNCopyNumberValue.NA ? (
+                {ascnCopyNumberCall !== ASCNCopyNumberValueEnum.NA ? (
                     <span>
                         {' '}
                         ({props.wgdValue} with total copy number of{' '}
@@ -159,7 +159,7 @@ const ASCNCopyNumberIcon: React.FunctionComponent<{
 }> = props => {
     return (
         <svg width="18" height="20" className="case-label-header">
-            {props.wgdValue === ASCNCopyNumberValue.WGD ? (
+            {props.wgdValue === ASCNCopyNumberValueEnum.WGD ? (
                 <svg>
                     <text
                         x="9"
@@ -213,9 +213,9 @@ const ASCNCopyNumberElement: React.FunctionComponent<{
     sampleManager?: SampleManager | null;
 }> = props => {
     const hasAllRequiredValues: boolean =
-        props.totalCopyNumberValue !== ASCNCopyNumberValue.NA &&
-        props.ascnCopyNumberValue !== ASCNCopyNumberValue.NA &&
-        props.wgdValue !== ASCNCopyNumberValue.NA &&
+        props.totalCopyNumberValue !== ASCNCopyNumberValueEnum.NA &&
+        props.ascnCopyNumberValue !== ASCNCopyNumberValueEnum.NA &&
+        props.wgdValue !== ASCNCopyNumberValueEnum.NA &&
         getASCNCopyNumberColor(props.ascnCopyNumberValue) !== ASCN_BLACK;
 
     if (hasAllRequiredValues) {
@@ -237,9 +237,9 @@ const ASCNCopyNumberElement: React.FunctionComponent<{
         return (
             <span>
                 <ASCNCopyNumberIcon
-                    wgdValue={ASCNCopyNumberValue.NA}
+                    wgdValue={ASCNCopyNumberValueEnum.NA}
                     totalCopyNumberValue=""
-                    ascnCopyNumberValue={ASCNCopyNumberValue.NA}
+                    ascnCopyNumberValue={ASCNCopyNumberValueEnum.NA}
                 />
             </span>
         );

--- a/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnMethod/ASCNMethodColumnFormatter.spec.tsx
@@ -44,5 +44,4 @@ describe('ASCNMethodColumnFormatter', () => {
             'ASCN method should be an empty string if not available for a mutation'
         );
     });
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/cancerCellFraction/CancerCellFractionColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/cancerCellFraction/CancerCellFractionColumnFormatter.spec.tsx
@@ -46,8 +46,6 @@ describe('CancerCellFractionColumnFormatter', () => {
         ).to.deep.equal(expectedSampleToCCFValue);
     }
 
-    before(() => {});
-
     // no SampleManager, single sample
     it('generates CancerCellFractionElement for single valid sample with right properties', () => {
         const validSingleSampleCCFColumn = mount(
@@ -98,6 +96,4 @@ describe('CancerCellFractionColumnFormatter', () => {
         );
         expect(validMultiSampleCCFColumn.find('DefaultTooltip')).to.exist;
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/cancerCellFraction/CancerCellFractionElement.spec.tsx
+++ b/src/shared/components/mutationTable/column/cancerCellFraction/CancerCellFractionElement.spec.tsx
@@ -94,8 +94,6 @@ describe('CancerCellFractionElement', () => {
         ).to.equal(expectedCCFValue);
     }
 
-    before(() => {});
-
     it('renders correctly for valid single sample', () => {
         const validSingleSampleCancerCellFractionColumn = mount(
             <CancerCellFractionElement
@@ -210,6 +208,4 @@ describe('CancerCellFractionElement', () => {
             'NA'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/clonal/ClonalColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/clonal/ClonalColumnFormatter.spec.tsx
@@ -70,8 +70,6 @@ describe('ClonalColumnFormatter', () => {
     let clonalColumnTest: ReactWrapper<any, any>;
     let clonalNoComponent: ReactWrapper<any, any>;
 
-    before(() => {});
-
     it('has expected number of ClonalElement components', () => {
         clonalColumnTest = mount(
             getDefaultClonalColumnDefinition(

--- a/src/shared/components/mutationTable/column/clonal/ClonalElement.spec.tsx
+++ b/src/shared/components/mutationTable/column/clonal/ClonalElement.spec.tsx
@@ -28,8 +28,6 @@ describe('ClonalElement', () => {
         ccfMCopies: 'NA',
     };
 
-    before(() => {});
-
     function testExpectedValidClonalElement(
         componentProperties: any,
         expectedColor: string
@@ -114,6 +112,4 @@ describe('ClonalElement', () => {
     it('generates lightgrey circle with tooltip for clonal NA', () => {
         testExpectedInvalidClonalElement(clonalNA, ClonalColor.LIGHTGREY);
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.spec.tsx
@@ -92,8 +92,6 @@ describe('MutantCopiesColumnFormatter', () => {
         createMutationWithMissingData('S006', ['alleleSpecificCopyNumber']),
     ];
 
-    before(() => {});
-
     it('has expected number of MutantCopiesElement components', () => {
         // only mutations with tcn/mutantCopies available map to an element
         let mutantCopiesColumnTest = mount(

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesColumnFormatter.tsx
@@ -3,7 +3,7 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { hasASCNProperty } from 'shared/lib/MutationUtils';
 import SampleManager from 'pages/patientView/SampleManager';
 import MutantCopiesElement from 'shared/components/mutationTable/column/mutantCopies/MutantCopiesElement';
-import { RV_NA } from 'shared/constants';
+import { RESPONSE_VALUE_NA } from 'shared/constants';
 
 /**
  * @author Avery Wang
@@ -93,13 +93,13 @@ export default class MutantCopiesColumnFormatter {
                 'totalCopyNumber'
             )
                 ? mutation.alleleSpecificCopyNumber.totalCopyNumber.toString()
-                : RV_NA;
+                : RESPONSE_VALUE_NA;
             sampleToMutantCopies[mutation.sampleId] = hasASCNProperty(
                 mutation,
                 'mutantCopies'
             )
                 ? mutation.alleleSpecificCopyNumber.mutantCopies.toString()
-                : RV_NA;
+                : RESPONSE_VALUE_NA;
         }
 
         // exclude samples with invalid count value (undefined || emtpy || lte 0)
@@ -107,8 +107,8 @@ export default class MutantCopiesColumnFormatter {
             sampleId =>
                 sampleToTotalCopyNumber[sampleId] &&
                 sampleToMutantCopies[sampleId] &&
-                sampleToTotalCopyNumber[sampleId] !== RV_NA &&
-                sampleToMutantCopies[sampleId] !== RV_NA
+                sampleToTotalCopyNumber[sampleId] !== RESPONSE_VALUE_NA &&
+                sampleToMutantCopies[sampleId] !== RESPONSE_VALUE_NA
         );
 
         return (

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesElement.spec.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesElement.spec.tsx
@@ -40,8 +40,6 @@ describe('MutantCopiesElement', () => {
         ).to.exist;
     }
 
-    before(() => {});
-
     it('generates MutantCopiesElement with Tooltip', () => {
         // only mutations with tcn/mutantCopies available map to an element
         let mutantCopiesElementTest = mount(
@@ -50,6 +48,4 @@ describe('MutantCopiesElement', () => {
         expect(mutantCopiesElementTest.find('span').text()).to.equal('2/4');
         testMutantCopiesElementTooltip(mutantCopiesElementTest);
     });
-
-    after(() => {});
 });

--- a/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesElement.tsx
+++ b/src/shared/components/mutationTable/column/mutantCopies/MutantCopiesElement.tsx
@@ -20,9 +20,7 @@ export const MutantCopiesElementTooltip: React.FunctionComponent<{
                 </span>
             ) : null}
             <span>
-                {' '}
-                {props.mutantCopiesValue} out of {props.totalCopyNumberValue}{' '}
-                copies of this gene are mutated.
+                {` ${props.mutantCopiesValue} out of ${props.totalCopyNumberValue} copies of this gene are mutated.`}
             </span>
         </span>
     );

--- a/src/shared/components/simpleTable/SimpleTable.spec.tsx
+++ b/src/shared/components/simpleTable/SimpleTable.spec.tsx
@@ -23,8 +23,6 @@ describe('SimpleTable', () => {
         table = shallow(<SimpleTable headers={headers} rows={rows} />);
     });
 
-    after(() => {});
-
     it('renders 3 rows if passed headers and two rows', () => {
         assert.equal(table.find('tr').length, 3);
     });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,44 +6,53 @@ export const PUTATIVE_DRIVER = 'Putative_Driver';
 export const SAMPLE_CANCER_TYPE_UNKNOWN = 'Unknown';
 
 /* cbioportal api request arguments */
-
-export const RARG_PROJECTION_META = 'META';
-export const RARG_PROJECTION_SUMMARY = 'SUMMARY';
-export const RARG_PROJECTION_DETAILED = 'DETAILED';
-export const RARG_CASE_TYPE_PATIENT = 'PATIENT';
-export const RARG_CASE_TYPE_SAMPLE = 'SAMPLE';
-export const RARG_CLINICAL_DATA_TYPE_PATIENT = 'PATIENT';
-export const RARG_CLINICAL_DATA_TYPE_SAMPLE = 'SAMPLE';
+export const enum REQUEST_ARG_ENUM {
+    PROJECTION_META = 'META',
+    PROJECTION_SUMMARY = 'SUMMARY',
+    PROJECTION_DETAILED = 'DETAILED',
+    CLINICAL_DATA_TYPE_PATIENT = 'PATIENT',
+    CLINICAL_DATA_TYPE_SAMPLE = 'SAMPLE',
+}
 
 /* cbioportal api responses */
 
 /* cbioportal api responses - general response values */
-export const RV_NA = 'NA';
+export const RESPONSE_VALUE_NA = 'NA';
 
 /* cbioportal api responses - clinical attribute identifiers */
-export const CAID_CANCER_TYPE = 'CANCER_TYPE';
-export const CAID_CANCER_TYPE_DETAILED = 'CANCER_TYPE_DETAILED';
-export const CAID_FACETS_PURITY = 'FACETS_PURITY';
-export const CAID_FACETS_WGD = 'FACETS_WGD';
+export const enum CLINICAL_ATTRIBUTE_ID_ENUM {
+    CANCER_TYPE = 'CANCER_TYPE',
+    CANCER_TYPE_DETAILED = 'CANCER_TYPE_DETAILED',
+    FACETS_PURITY = 'FACETS_PURITY',
+    FACETS_WGD = 'FACETS_WGD',
+}
 
 /* cbioportal api responses - clinical attribute fields and subfields */
-export const CAF_ID = 'clinicalAttributeId';
-export const CAF_DATATYPE_NUMBER = 'NUMBER';
-export const CAF_DATATYPE_STRING = 'STRING';
-export const CAF_DATATYPE_COUNTS_MAP = 'COUNTS_MAP';
+export const enum CLINICAL_ATTRIBUTE_FIELD_ENUM {
+    ID = 'clinicalAttributeId',
+    DATATYPE_NUMBER = 'NUMBER',
+    DATATYPE_STRING = 'STRING',
+    DATATYPE_COUNTS_MAP = 'COUNTS_MAP',
+}
 
 /* cbioportal api responses - mutation data fields and subfields */
-export const MDF_ASCN_INTEGER_COPY_NUMBER = 'ascnIntegerCopyNumber';
-export const MDF_TOTAL_COPY_NUMBER = 'totalCopyNumber';
-export const MDF_MINOR_COPY_NUMBER = 'minorCopyNumber';
-export const MDF_MUTANT_COPIES = 'mutantCopies';
+export const enum MUTATION_DATA_FIELD_ENUM {
+    ASCN_INTEGER_COPY_NUMBER = 'ascnIntegerCopyNumber',
+    TOTAL_COPY_NUMBER = 'totalCopyNumber',
+    MINOR_COPY_NUMBER = 'minorCopyNumber',
+    MUTANT_COPIES = 'mutantCopies',
+}
 
 /* cbioportal api responses - genetic profile fields and subfields */
-export const GPF_MOLECULAR_ALTERATION_TYPE = 'molecularAlterationType';
-export const GPF_STUDY_ID = 'studyId';
+export const enum GENETIC_PROFILE_FIELD_ENUM {
+    MOLECULAR_ALTERATION_TYPE = 'molecularAlterationType',
+    STUDY_ID = 'studyId',
+}
 
 /* genome nexus api request arguments */
-export const GNARG_FIELD_ANNOTATION_SUMMARY = 'annotation_summary';
-export const GNARG_FIELD_HOTSPOTS = 'hotspots';
-export const GNARG_FIELD_MUTATION_ASSESSOR = 'mutation_assessor';
-export const GNARG_FIELD_MY_VARIANT_INFO = 'my_variant_info';
+export const enum GENOME_NEXUS_ARG_FIELD_ENUM {
+    ANNOTATION_SUMMARY = 'annotation_summary',
+    HOTSPOTS = 'hotspots',
+    MUTATION_ASSESSOR = 'mutation_assessor',
+    MY_VARIANT_INFO = 'my_variant_info',
+}

--- a/src/shared/lib/ASCNUtils.ts
+++ b/src/shared/lib/ASCNUtils.ts
@@ -8,8 +8,10 @@ import {
     ASCN_BLACK,
 } from 'shared/lib/Colors';
 
-export function getASCNCopyNumberColor(ASCNCopyNumberValue: string): string {
-    switch (ASCNCopyNumberValue) {
+export function getASCNCopyNumberColor(
+    ASCNCopyNumberValueEnum: string
+): string {
+    switch (ASCNCopyNumberValueEnum) {
         case '2':
             return ASCN_AMP;
         case '1':

--- a/src/shared/lib/AnnotationUtils.spec.tsx
+++ b/src/shared/lib/AnnotationUtils.spec.tsx
@@ -233,6 +233,4 @@ describe('AnnotationUtils', () => {
             'SMURF1 R101N should be a 3d hotspot mutation.'
         );
     });
-
-    after(() => {});
 });

--- a/src/shared/lib/CancerHotspotsUtils.spec.ts
+++ b/src/shared/lib/CancerHotspotsUtils.spec.ts
@@ -4,8 +4,6 @@ import { Mutation } from 'cbioportal-ts-api-client';
 import { filterMutationsOnNonHotspotGenes } from './CancerHotspotsUtils';
 
 describe('CancerHotspotsUtils', () => {
-    before(() => {});
-
     describe('filterMutationsOnNonHotspotGenes', () => {
         it('filters mutations on non hotspot genes', () => {
             const mutations = [
@@ -17,6 +15,4 @@ describe('CancerHotspotsUtils', () => {
             );
         });
     });
-
-    after(() => {});
 });

--- a/src/shared/lib/MutationInputParser.spec.ts
+++ b/src/shared/lib/MutationInputParser.spec.ts
@@ -143,8 +143,6 @@ describe('MutationInputParser', () => {
         'TCGA-24-1104\tCancerType3\n' +
         'Unknown\tCancerType4';
 
-    before(() => {});
-
     it('extracts mutation input headers', () => {
         const separator = '\t';
         const richInputIndexMap = buildIndexMap(

--- a/src/shared/lib/StoreUtils.spec.ts
+++ b/src/shared/lib/StoreUtils.spec.ts
@@ -191,8 +191,6 @@ describe('StoreUtils', () => {
         };
     });
 
-    after(() => {});
-
     describe('fetchCosmicCount', () => {
         it("won't fetch cosmic data if there are no mutations", done => {
             const fetchStub = sinon.stub();


### PR DESCRIPTION
* Use template literals
* Moving groups of constants to enums
* ASCNCopyNumberValue -> ASCNCopyNumberValueEnum
* ASCNCopyNumberOpacity -> ASCNCopyNumberOpacityEnum
* Removed all empty before and after method calls from unit tests (left in unit test template files)