### PR TITLE
Relocate logic for detecting ascn data into stores

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -1206,6 +1206,11 @@ export default class PatientViewPage extends React.Component<
                                                             .patientViewPageStore
                                                             .clinicalDataGroupedBySampleMap
                                                     }
+                                                    existsSomeMutationWithAscnProperty={
+                                                        this
+                                                            .patientViewPageStore
+                                                            .existsSomeMutationWithAscnProperty
+                                                    }
                                                 />
                                             </div>
                                         )}

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -59,6 +59,7 @@ import MutationCountCache from 'shared/cache/MutationCountCache';
 import AppConfig from 'appConfig';
 import {
     concatMutationData,
+    existsSomeMutationWithAscnPropertyInCollection,
     fetchClinicalData,
     fetchClinicalDataForPatient,
     fetchCnaOncoKbData,
@@ -104,7 +105,7 @@ import { fetchHotspotsData } from 'shared/lib/CancerHotspotsUtils';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import { CancerGene } from 'oncokb-ts-api-client';
 import { MutationTableDownloadDataFetcher } from 'shared/lib/MutationTableDownloadDataFetcher';
-import { getNavCaseIdsCache } from '../../../shared/lib/handleLongUrls';
+import { getNavCaseIdsCache } from 'shared/lib/handleLongUrls';
 import {
     fetchTrialMatchesUsingPOST,
     fetchTrialsById,
@@ -122,7 +123,7 @@ import {
     computeGenePanelInformation,
     CoverageInformation,
 } from '../../resultsView/ResultsViewPageStoreUtils';
-import { getVariantAlleleFrequency } from '../../../shared/lib/MutationUtils';
+import { getVariantAlleleFrequency } from 'shared/lib/MutationUtils';
 import { AppStore, SiteError } from 'AppStore';
 import { getGeneFilterDefault } from './PatientViewPageStoreUtil';
 import { checkNonProfiledGenesExist } from '../PatientViewPageUtils';
@@ -1450,6 +1451,14 @@ export class PatientViewPageStore {
                     return vaf != null && vaf > 0;
                 });
             }
+        );
+    }
+
+    @computed get existsSomeMutationWithAscnProperty(): {
+        [property: string]: boolean;
+    } {
+        return existsSomeMutationWithAscnPropertyInCollection(
+            this.mergedMutationDataIncludingUncalled
         );
     }
 

--- a/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.spec.tsx
@@ -38,6 +38,7 @@ function getTable(
             ]}
             data={[]}
             generateGenomeNexusHgvsgUrl={(s: string) => s}
+            existsSomeMutationWithAscnProperty={{}}
         />
     );
 }

--- a/src/pages/patientView/mutation/PatientViewMutationTable.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationTable.tsx
@@ -6,6 +6,7 @@ import {
     MutationTableColumnType,
     default as MutationTable,
 } from 'shared/components/mutationTable/MutationTable';
+import PatientViewMutationsDataStore from './PatientViewMutationsDataStore';
 import SampleManager from '../SampleManager';
 import { Mutation } from 'cbioportal-ts-api-client';
 import AlleleCountColumnFormatter from 'shared/components/mutationTable/column/AlleleCountColumnFormatter';
@@ -33,6 +34,7 @@ export interface IPatientViewMutationTableProps extends IMutationTableProps {
     onFilterGenes?: (option: GeneFilterOption) => void;
     onSelectGenePanel?: (name: string) => void;
     disableTooltip?: boolean;
+    existsSomeMutationWithAscnProperty: { [property: string]: boolean };
 }
 
 @observer
@@ -314,33 +316,33 @@ export default class PatientViewMutationTable extends MutationTable<
         };
 
         this._columns[MutationTableColumnType.CLONAL].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.CCF_M_COPIES_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.ASCN_METHOD
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.ASCN_METHOD_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.CANCER_CELL_FRACTION
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.CCF_M_COPIES_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.MUTANT_COPIES
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.MUTANT_COPIES_STRING
-            );
+            ];
         };
 
         // only hide tumor column if there is one sample and no uncalled

--- a/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
+++ b/src/pages/patientView/mutation/PatientViewMutationsTab.tsx
@@ -347,6 +347,9 @@ export default class PatientViewMutationsTab extends React.Component<
                     sampleIdToClinicalDataMap={
                         this.props.store.clinicalDataGroupedBySampleMap
                     }
+                    existsSomeMutationWithAscnProperty={
+                        this.props.store.existsSomeMutationWithAscnProperty
+                    }
                 />
             </div>
         ),

--- a/src/pages/resultsView/ResultsViewPageStore.ts
+++ b/src/pages/resultsView/ResultsViewPageStore.ts
@@ -58,6 +58,7 @@ import DiscreteCNACache from 'shared/cache/DiscreteCNACache';
 import PdbHeaderCache from 'shared/cache/PdbHeaderCache';
 import {
     cancerTypeForOncoKb,
+    existsSomeMutationWithAscnPropertyInCollection,
     fetchAllReferenceGenomeGenes,
     fetchCnaOncoKbDataWithNumericGeneMolecularData,
     fetchCopyNumberSegmentsForSamples,
@@ -2711,6 +2712,20 @@ export class ResultsViewPageStore {
             );
         },
     });
+
+    @computed get existsSomeMutationWithAscnProperty(): {
+        [property: string]: boolean;
+    } {
+        if (this.mutations.result === undefined) {
+            return existsSomeMutationWithAscnPropertyInCollection(
+                [] as Mutation[]
+            );
+        } else {
+            return existsSomeMutationWithAscnPropertyInCollection(
+                this.mutations.result
+            );
+        }
+    }
 
     public mutationsTabFilteringSettings = this.makeMutationsTabFilteringSettings();
 

--- a/src/pages/resultsView/mutation/Mutations.tsx
+++ b/src/pages/resultsView/mutation/Mutations.tsx
@@ -163,6 +163,10 @@ export default class Mutations extends React.Component<
                             generateGenomeNexusHgvsgUrl={
                                 this.props.store.generateGenomeNexusHgvsgUrl
                             }
+                            existsSomeMutationWithAscnProperty={
+                                this.props.store
+                                    .existsSomeMutationWithAscnProperty
+                            }
                         />
                     </MSKTab>
                 );

--- a/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationMapper.tsx
@@ -27,6 +27,7 @@ export interface IResultsViewMutationMapperProps extends IMutationMapperProps {
     discreteCNACache?: DiscreteCNACache;
     cancerTypeCache?: CancerTypeCache;
     mutationCountCache?: MutationCountCache;
+    existsSomeMutationWithAscnProperty: { [property: string]: boolean };
     genomeNexusMyVariantInfoCache?: GenomeNexusMyVariantInfoCache;
     userEmailAddress: string;
 }
@@ -144,6 +145,9 @@ export default class ResultsViewMutationMapper extends MutationMapper<
                 }
                 sampleIdToClinicalDataMap={
                     this.props.store.clinicalDataGroupedBySampleMap
+                }
+                existsSomeMutationWithAscnProperty={
+                    this.props.existsSomeMutationWithAscnProperty
                 }
             />
         );

--- a/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
+++ b/src/pages/resultsView/mutation/ResultsViewMutationTable.tsx
@@ -15,6 +15,7 @@ import { ASCNAttributes } from 'shared/enums/ASCNEnums';
 export interface IResultsViewMutationTableProps extends IMutationTableProps {
     // add results view specific props here if needed
     totalNumberOfExons?: string;
+    existsSomeMutationWithAscnProperty: { [property: string]: boolean };
 }
 //
 @observer
@@ -140,33 +141,33 @@ export default class ResultsViewMutationTable extends MutationTable<
         };
 
         this._columns[MutationTableColumnType.CLONAL].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.CCF_M_COPIES_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.ASCN_METHOD
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.ASCN_METHOD_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.CANCER_CELL_FRACTION
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.CCF_M_COPIES_STRING
-            );
+            ];
         };
 
         this._columns[
             MutationTableColumnType.MUTANT_COPIES
         ].shouldExclude = () => {
-            return !this.anyMutationHasASCNProperty(
+            return !this.props.existsSomeMutationWithAscnProperty[
                 ASCNAttributes.MUTANT_COPIES_STRING
-            );
+            ];
         };
 
         this._columns[

--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -1125,33 +1125,4 @@ export default class MutationTable<
             />
         );
     }
-
-    @computed protected get getMutations() {
-        let data: Mutation[][] | undefined = [];
-        if (this.props.dataStore) {
-            data = this.props.dataStore.allData;
-        } else if (this.props.data) {
-            data = this.props.data;
-        }
-        return data;
-    }
-
-    /**
-     * searches all available mutation data for any mutation with the passed field key
-     * @param property the field name to search for
-     * @returns true if any available mutation is annotated with the passed property name
-     */
-    protected anyMutationHasASCNProperty(property: string): boolean {
-        let data = this.getMutations;
-        if (data) {
-            return data.some((row: Mutation[]) => {
-                /* if at least one row ... */
-                return row.some((m: Mutation) => {
-                    /* contains at least one mutation record ... */
-                    return hasASCNProperty(m, property);
-                });
-            });
-        }
-        return false;
-    }
 }

--- a/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
+++ b/src/shared/components/mutationTable/column/ascnCopyNumber/ASCNCopyNumberColumnFormatter.spec.tsx
@@ -293,7 +293,7 @@ describe('ASCNCopyNumberColumnFormatter', () => {
             isPending: false,
             isError: true,
             isComplete: false,
-            error: 'MockError' as 'MockError',
+            error: new Error('MockError'),
         };
     }
 

--- a/src/shared/enums/ASCNEnums.ts
+++ b/src/shared/enums/ASCNEnums.ts
@@ -1,5 +1,10 @@
 export enum ASCNAttributes {
+    ASCN_INTEGER_COPY_NUMBER_STRING = 'ascnIntegerCopyNumber',
+    ASCN_METHOD_STRING = 'ascnMethod',
     CCF_M_COPIES_STRING = 'ccfMCopies',
+    CCF_M_COPIES_UPPER_STRING = 'ccfMCopiesUpper',
+    CLONAL_STRING = 'clonal',
+    MINOR_COPY_NUMBER_STRING = 'minorCopyNumber',
     MUTANT_COPIES_STRING = 'mutantCopies',
-    ASCN_METHOD_STRING = 'ascnMethod', 
+    TOTAL_COPY_NUMBER_STRING = 'totalCopyNumber',
 }

--- a/src/shared/lib/StoreUtils.ts
+++ b/src/shared/lib/StoreUtils.ts
@@ -77,6 +77,8 @@ import {
 } from 'oncokb-ts-api-client';
 import { EvidenceType, IOncoKbData } from 'cbioportal-frontend-commons';
 import { REFERENCE_GENOME } from './referenceGenomeUtils';
+import { ASCNAttributes } from 'shared/enums/ASCNEnums';
+import { hasASCNProperty } from 'shared/lib/MutationUtils';
 
 export const ONCOKB_DEFAULT: IOncoKbData = {
     indicatorMap: {},
@@ -1174,6 +1176,47 @@ export function generateMutationIdByGeneAndProteinChangeAndEvent(
         m.proteinChange,
         ...mutationEventFields(m),
     ].join('_');
+}
+
+/** scan a collection of Mutations to see if any contain values for ASCN fields/properties
+ *
+ * all mutations (whether passed as a simple array or as an array of array)
+ * are scanned (once per known ASCN field/property) to see whether any mutation can be found
+ * which has a (non-empty) value defined for the field. A map from field name to boolean
+ * result is returned.
+ *
+ * @param mutations - a union type (either array of Mutation or array of array of Mutation)
+ * @returns Object/Dictionary with key from {ASCN_field_names} and boolean value per key
+ */
+export function existsSomeMutationWithAscnPropertyInCollection(
+    mutations: Mutation[] | Mutation[][]
+): {
+    [property: string]: boolean;
+} {
+    const existsSomeMutationWithAscnPropertyMap: {
+        [property: string]: boolean;
+    } = {};
+    for (let p of Object.values(ASCNAttributes)) {
+        if (mutations.length == 0) {
+            existsSomeMutationWithAscnPropertyMap[p] = false;
+            continue;
+        }
+        existsSomeMutationWithAscnPropertyMap[p] = _.some(
+            mutations,
+            mutationElement => {
+                if (mutationElement.hasOwnProperty('variantAllele')) {
+                    // element is a single mutation
+                    return hasASCNProperty(mutationElement as Mutation, p);
+                } else {
+                    // element is a mutation array
+                    return _.some(mutationElement as Mutation[], m => {
+                        return hasASCNProperty(m, p);
+                    });
+                }
+            }
+        );
+    }
+    return existsSomeMutationWithAscnPropertyMap;
 }
 
 export function generateDataQueryFilter(


### PR DESCRIPTION
- ascn property presence logic taken out of MutationTable
- ascn property presence logic added to StoreUtils.ts
- computed getter added to PatientViewPageStore and ResultsViewPageStore (calling shared function in StoreUtils)
- compuited property set and passed down which holds map of ascn_field_name : boolean
Bug fix for unit tests, testing an error to fetch ascn clinical attribute
